### PR TITLE
Fixed FocusGained bug in Windows GVim

### DIFF
--- a/plugin/signify.vim
+++ b/plugin/signify.vim
@@ -112,7 +112,7 @@ augroup signify
   endif
   autocmd ColorScheme * call s:colors_set()
   autocmd BufWritePost,BufEnter * call s:start(resolve(expand('<afile>:p')))
-  if !(has("gui_win32 ))
+  if !(has("gui_win32"))
     autocmd FocusGained * call s:start(resolve(expand('<afile>:p')))
   endif
 augroup END


### PR DESCRIPTION
Using the FocusGained autocmd spawns shells in an infinite loop. Putting the autocommand in an "if" statement that allows all Vims except GVim on Windows to use it fixes the issue.
