### PR TITLE
Add g:signify_bufenter option

### DIFF
--- a/plugin/signify.vim
+++ b/plugin/signify.vim
@@ -80,13 +80,16 @@ augroup signify
     autocmd CursorHoldI * write | call s:start(s:path)
   endif
 
+  if get(g:, 'g:signify_bufenter', 0) == 1
+    autocmd BufEnter * let s:path = resolve(expand('<afile>:p')) | call s:start(s:path)
+  endif
+
   if !has('gui_win32')
     autocmd FocusGained * call s:start(resolve(expand('<afile>:p')))
   endif
 
   autocmd VimEnter,ColorScheme  * call s:colors_set()
-  autocmd BufEnter              * let s:path = resolve(expand('<afile>:p'))
-  autocmd BufEnter,BufWritePost * call s:start(s:path)
+  autocmd BufWritePost * let s:path = resolve(expand('<afile>:p')) | call s:start(s:path)
 augroup END
 
 " Init: commands {{{1


### PR DESCRIPTION
Depend on the size of the git repo, for example, `git diff` can be slow (at least in my environment). So, I suggest to make `BufEnter` autocmd optional. 
