### PR TITLE
Fix a bug where starting vim from a directory would produce an error

### DIFF
--- a/plugin/signify.vim
+++ b/plugin/signify.vim
@@ -77,9 +77,11 @@ augroup signify
   endif
 
   autocmd BufDelete *
-        \ call s:stop(s:path) |
-        \ if has_key(s:sy, s:path) |
-        \   call remove(s:sy, s:path) |
+        \ if exists('s:path') |
+        \   call s:stop(s:path) |
+        \   if has_key(s:sy, s:path) |
+        \     call remove(s:sy, s:path) |
+        \   endif |
         \ endif
 augroup END
 


### PR DESCRIPTION
Fix a bug where starting vim from a directory would produce the following error:

```
Error detected while processing BufDelete Auto commands for "*":
E121: Undefined variable: s:path
E116: Invalid arguments for function <SNR>62_stop
```
