### PR TITLE
Make "jump to hunk" behave like the builtin ]c/[c

### DIFF
--- a/doc/signify.txt
+++ b/doc/signify.txt
@@ -216,7 +216,7 @@ Default mapping:  <leader>gh
 
     :SignifyJumpToNextHunk
 
-Jump to the next hunk. There are two mappings available:
+Jump to the next start of a hunk. There are two mappings available:
 
 Hardcoded mapping:     ]c
 Configurable mapping:  <leader>gj
@@ -225,7 +225,7 @@ Configurable mapping:  <leader>gj
 
     :SignifyJumpToPrevHunk
 
-Jump to the previous hunk. There are two mappings available:
+Jump to the previous start of a hunk. There are two mappings available:
 
 Hardcoded mapping:     [c
 Configurable mapping:  <leader>gk


### PR DESCRIPTION
Instead of using the sign id as the primary piece of data, store
information on a per-hunk granularity.  A hunk has a start/end line as
well as a set of sign ids that have been placed within those lines.

This makes moving to the start of the next/previous hunk, as per the
behavior of the standard `]c`/`[c` bindings, pretty straight forward --
a simple filter to find relevant hunks, and then grab the first sign id.

This should address issue #35.
