### PR TITLE
remove redundant path modification for diff

### DIFF
--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -7,21 +7,11 @@ let b:autoloaded_sy_repo = 1
 if !empty(get(g:, 'signify_difftool'))
   let s:difftool = g:signify_difftool
 else
-  if has('win32')
-    if $VIMRUNTIME =~ ' '
-      let s:difftool = (&sh =~ '\<cmd')
-            \ ? ('"'. $VIMRUNTIME .'\diff"')
-            \ : (substitute($VIMRUNTIME, ' ', '" ', '') .'\diff"')
-    else
-      let s:difftool = $VIMRUNTIME .'\diff'
-    endif
-  else
-    if !executable('diff')
-      echomsg 'signify: No diff tool found!'
-      finish
-    endif
-    let s:difftool = 'diff'
+  if !executable('diff')
+    echomsg 'signify: No diff tool found!'
+    finish
   endif
+  let s:difftool = 'diff'
 endif
 
 let s:diffoptions = get(g:, 'signify_diffoptions', {})


### PR DESCRIPTION
the runtime directory is automatically added to the path; see `:h win32-path`; so `diff.exe` should be available.

this also "fixes" the error introduced with commit https://github.com/mhinz/vim-signify/commit/9a78f90e1aa2a656366217d1bcea70ed76b68309, since we're supplying only `diff` to the `--diff-command` now instead of something with spaces.
