### PR TITLE
Fixed bug that shadowed mappings

### DIFF
--- a/plugin/signify.vim
+++ b/plugin/signify.vim
@@ -62,33 +62,33 @@ nnoremap <silent> <plug>(signify-toggle)           :<c-u>call sy#toggle()<cr>
 
 if exists('g:signify_mapping_next_hunk')
   execute 'nmap '. g:signify_mapping_next_hunk .' <plug>(signify-next-hunk)'
-elseif !hasmapto('<plug>(signify-next-hunk)') && !maparg('<leader>gj', 'n')
+elseif !hasmapto('<plug>(signify-next-hunk)') && empty(maparg('<leader>gj', 'n'))
   nmap <leader>gj <plug>(signify-next-hunk)
 endif
 
 if exists('g:signify_mapping_prev_hunk')
   execute 'nmap '. g:signify_mapping_prev_hunk .' <plug>(signify-prev-hunk)'
-elseif !hasmapto('<plug>(signify-prev-hunk)') && !maparg('<leader>gk', 'n')
+elseif !hasmapto('<plug>(signify-prev-hunk)') && empty(maparg('<leader>gk', 'n'))
   nmap <leader>gk <plug>(signify-prev-hunk)
 endif
 
 if exists('g:signify_mapping_toggle_highlight')
   execute 'nmap '. g:signify_mapping_toggle_highlight .' <plug>(signify-toggle-highlight)'
-elseif !hasmapto('<plug>(signify-toggle-highlight)') && !maparg('<leader>gh', 'n')
+elseif !hasmapto('<plug>(signify-toggle-highlight)') && empty(maparg('<leader>gh', 'n'))
   nmap <leader>gh <plug>(signify-toggle-highlight)
 endif
 
 if exists('g:signify_mapping_toggle')
   execute 'nmap '. g:signify_mapping_toggle .' <plug>(signify-toggle)'
-elseif !hasmapto('<plug>(signify-toggle)') && !maparg('<leader>gt', 'n')
+elseif !hasmapto('<plug>(signify-toggle)') && empty(maparg('<leader>gt', 'n'))
   nmap <leader>gt <plug>(signify-toggle)
 endif
 
-if !maparg(']c', 'n')
+if empty(maparg(']c', 'n'))
   nmap ]c <plug>(signify-next-hunk)
 endif
 
-if !maparg('[c', 'n')
+if empty(maparg('[c', 'n'))
   nmap [c <plug>(signify-prev-hunk)
 endif
 


### PR DESCRIPTION
Changed `!` for `empty` when testing for string emptiness.

Related to #65
