### PR TITLE
Checking executable() is slow, avoid when possible

### DIFF
--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -29,7 +29,11 @@ let s:vcs_dict = {
       \ 'perforce': 'p4'
       \ }
 
-let s:vcs_list    = get(g:, 'signify_vcs_list', keys(filter(s:vcs_dict, 'executable(v:val)')))
+if !empty(get(g:, 'signify_vcs_list'))
+  let s:vcs_list  = g:signify_vcs_list
+else
+  let s:vcs_list  = keys(filter(s:vcs_dict, 'executable(v:val)'))
+endif
 let s:diffoptions = get(g:, 'signify_diffoptions', {})
 
 " Function: #detect {{{1


### PR DESCRIPTION
Checking executable() for every possible VCS is fairly slow at startup.
This change, combined with specifying vcs and difftool, shaves of
155 ms (half) of my startup time.

```
let g:signify_vcs_list = ['git']
let g:signify_difftool = 'diff'
```

Feel free to throw away this and implement it in another way.
I don't like that specifying signify_difftool to the same value as default improves performance.
