### PR TITLE
Fix typo

### DIFF
--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -262,7 +262,7 @@ function! sy#repo#process_diff(path, diff) abort
         endwhile
 
         call add(signs, {
-              \ 'type': (removed > 9) ? 'SignifyChangeDeleteMore' : 'SignifyChangeDelete'. deleted,
+              \ 'type': (removed > 9) ? 'SignifyChangeDeleteMore' : 'SignifyChangeDelete'. removed,
               \ 'lnum': new_line,
               \ 'path': a:path })
 


### PR DESCRIPTION
When deleting a lot of lines I was getting

```
Error detected while processing function sy#toggle..sy#start..sy#repo#process_diff..sy#sign#set:
line   10:
E155: Unknown sign: SignifyChangeDelete12
```

since the sign number was above 9
