### PR TITLE
Dynamic read g:signify_diffoptions before each diff

### DIFF
--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -4,8 +4,13 @@ scriptencoding utf-8
 
 " Init: values {{{1
 
-let s:diffoptions = get(g:, 'signify_diffoptions', {})
 let s:difftool    = get(g:, 'signify_difftool', 'diff')
+
+if ! exists('g:signify_diffoptions')
+  " Create the variable if it doesn't already exist so we can use it in the
+  " functions below without an exists() check
+  let g:signify_diffoptions = {}
+endif
 
 if executable(s:difftool)
   let s:vcs_dict = {
@@ -64,7 +69,7 @@ endfunction
 
 " Function: #get_diff_git {{{1
 function! sy#repo#get_diff_git(path) abort
-  let diffoptions = has_key(s:diffoptions, 'git') ? s:diffoptions.git : ''
+  let diffoptions = has_key(g:signify_diffoptions, 'git') ? g:signify_diffoptions.git : ''
   let diff = system('cd '. sy#util#escape(fnamemodify(a:path, ':h')) .' && git diff --no-color --no-ext-diff -U0 '. diffoptions .' -- '. sy#util#escape(a:path))
 
   return v:shell_error ? [0, ''] : [1, diff]
@@ -103,7 +108,7 @@ endfunction
 
 " Function: #get_diff_hg {{{1
 function! sy#repo#get_diff_hg(path) abort
-  let diffoptions = has_key(s:diffoptions, 'hg') ? s:diffoptions.hg : ''
+  let diffoptions = has_key(g:signify_diffoptions, 'hg') ? g:signify_diffoptions.hg : ''
   let diff = system('hg diff --nodates -U0 '. diffoptions .' -- '. sy#util#escape(a:path))
 
   return v:shell_error ? [0, ''] : [1, diff]
@@ -111,7 +116,7 @@ endfunction
 
 " Function: #get_diff_svn {{{1
 function! sy#repo#get_diff_svn(path) abort
-  let diffoptions = has_key(s:diffoptions, 'svn') ? s:diffoptions.svn : ''
+  let diffoptions = has_key(g:signify_diffoptions, 'svn') ? g:signify_diffoptions.svn : ''
   let diff = system('svn diff --diff-cmd '. s:difftool .' -x -U0 '. diffoptions .' -- '. sy#util#escape(a:path))
 
   return v:shell_error ? [0, ''] : [1, diff]
@@ -119,7 +124,7 @@ endfunction
 
 " Function: #get_diff_bzr {{{1
 function! sy#repo#get_diff_bzr(path) abort
-  let diffoptions = has_key(s:diffoptions, 'bzr') ? s:diffoptions.bzr : ''
+  let diffoptions = has_key(g:signify_diffoptions, 'bzr') ? g:signify_diffoptions.bzr : ''
   let diff = system('bzr diff --using '. s:difftool .' --diff-options=-U0 '. diffoptions .' -- '. sy#util#escape(a:path))
 
   return (v:shell_error =~ '[012]') ? [1, diff] : [0, '']
@@ -127,42 +132,42 @@ endfunction
 
 " Function: #get_diff_darcs {{{1
 function! sy#repo#get_diff_darcs(path) abort
-  let diffoptions = has_key(s:diffoptions, 'darcs') ? s:diffoptions.darcs : ''
+  let diffoptions = has_key(g:signify_diffoptions, 'darcs') ? g:signify_diffoptions.darcs : ''
   let diff = system('cd '. sy#util#escape(fnamemodify(a:path, ':h')) .' && darcs diff --no-pause-for-gui --diff-command="'. s:difftool .' -U0 %1 %2 '. diffoptions .'" -- '. sy#util#escape(a:path))
   return v:shell_error ? [0, ''] : [1, diff]
 endfunction
 
 " Function: #get_diff_fossil {{{1
 function! sy#repo#get_diff_fossil(path) abort
-  let diffoptions = has_key(s:diffoptions, 'fossil') ? s:diffoptions.fossil : ''
+  let diffoptions = has_key(g:signify_diffoptions, 'fossil') ? g:signify_diffoptions.fossil : ''
   let diff = system('cd '. sy#util#escape(fnamemodify(a:path, ':h')) .' && fossil set diff-command "'. s:difftool .' -U 0" && fossil diff --unified -c 0 '. diffoptions .' -- '. sy#util#escape(a:path))
   return v:shell_error ? [0, ''] : [1, diff]
 endfunction
 
 " Function: #get_diff_cvs {{{1
 function! sy#repo#get_diff_cvs(path) abort
-  let diffoptions = has_key(s:diffoptions, 'cvs') ? s:diffoptions.cvs : ''
+  let diffoptions = has_key(g:signify_diffoptions, 'cvs') ? g:signify_diffoptions.cvs : ''
   let diff = system('cd '. sy#util#escape(fnamemodify(a:path, ':h')) .' && cvs diff -U0 '. diffoptions .' -- '. sy#util#escape(fnamemodify(a:path, ':t')))
   return ((v:shell_error == 1) && (diff =~ '+++')) ? [1, diff] : [0, '']
 endfunction
 
 " Function: #get_diff_rcs {{{1
 function! sy#repo#get_diff_rcs(path) abort
-  let diffoptions = has_key(s:diffoptions, 'rcs') ? s:diffoptions.rcs : ''
+  let diffoptions = has_key(g:signify_diffoptions, 'rcs') ? g:signify_diffoptions.rcs : ''
   let diff = system('rcsdiff -U0 '. diffoptions .' '. sy#util#escape(a:path) .' 2>/dev/null')
   return v:shell_error ? [0, ''] : [1, diff]
 endfunction
 
 " Function: #get_diff_accurev {{{1
 function! sy#repo#get_diff_accurev(path) abort
-  let diffoptions = has_key(s:diffoptions, 'accurev') ? s:diffoptions.accurev : ''
+  let diffoptions = has_key(g:signify_diffoptions, 'accurev') ? g:signify_diffoptions.accurev : ''
   let diff = system('cd '. sy#util#escape(fnamemodify(a:path, ':h')) .' && accurev diff '. sy#util#escape(fnamemodify(a:path, ':t')) . ' -- -U0 '. diffoptions)
   return (v:shell_error != 1) ? [0, ''] : [1, diff]
 endfunction
 
 " Function: #get_diff_perforce {{{1
 function! sy#repo#get_diff_perforce(path) abort
-  let diffoptions = has_key(s:diffoptions, 'perforce') ? s:diffoptions.perforce : ''
+  let diffoptions = has_key(g:signify_diffoptions, 'perforce') ? g:signify_diffoptions.perforce : ''
   let diff = system('env P4DIFF=diff p4 diff -du0 '. diffoptions .' '. sy#util#escape(a:path))
   return v:shell_error ? [0, ''] : [1, diff]
 endfunction


### PR DESCRIPTION
Wanted to be able to diff against a different branch in git, but realized that this was not possible to do without changing my vimrc file, since signify-diffoptions is only looked at once.  

The change makes it so it is read from the global g:signify-diffoptions each time before diff is called.  This allows for the following use case (get applied next time diff is done, such as after a :SignifyToggle)
    # Show diff against master instead of against HEAD in Git
    nnoremap \u :let g:signify_diffoptions = { 'git': 'master' }<CR> 

This change will also allow any other arbitrary diff options to be dynamically updated, such as whitespace, etc.
