### PR TITLE
Move Sy's data from g:sy to b:sy

### DIFF
--- a/autoload/sy.vim
+++ b/autoload/sy.vim
@@ -26,26 +26,26 @@ function! sy#start(path) abort
   endif
 
   " new buffer.. add to list of registered files
-  if !has_key(g:sy, a:path)
+  if !exists('b:sy') || b:sy.path != a:path
+    let b:sy = { 'path': a:path, 'buffer': bufnr(''), 'active': 0, 'type': 'unknown', 'hunks': [], 'id_top': g:id_top, 'stats': [-1, -1, -1] }
     if get(g:, 'signify_disable_by_default')
-      " register file as inactive
-      let g:sy[a:path] = { 'active': 0, 'type': 'unknown', 'hunks': [], 'id_top': g:id_top, 'stats': [-1, -1, -1] }
       return
     endif
 
-    let [ diff, type ] = sy#repo#detect(a:path)
-    if type == 'unknown'
-      " register file as active with no found VCS
-      let g:sy[a:path] = { 'active': 1, 'type': 'unknown', 'hunks': [], 'id_top': g:id_top, 'stats': [0, 0, 0] }
+    " register buffer as active
+    let b:sy.active = 1
+
+    let [ diff, b:sy.type ] = sy#repo#detect()
+    if b:sy.type == 'unknown'
       return
     endif
 
     " register file as active with found VCS
-    let g:sy[a:path] = { 'active': 1, 'type': type, 'hunks': [], 'id_top': g:id_top, 'stats': [0, 0, 0] }
+    let b:sy.stats = [0, 0, 0]
 
-    let dir = fnamemodify(a:path, ':h')
+    let dir = fnamemodify(b:sy.path, ':h')
     if !has_key(g:sy_cache, dir)
-      let g:sy_cache[dir] = type
+      let g:sy_cache[dir] = b:sy.type
     endif
 
     if empty(diff)
@@ -54,26 +54,25 @@ function! sy#start(path) abort
     endif
 
   " inactive buffer.. bail out
-  elseif !g:sy[a:path].active
+  elseif !b:sy.active
     return
 
   " retry detecting VCS
-  elseif g:sy[a:path].type == 'unknown'
-    let [ diff, type ] = sy#repo#detect(a:path)
-    if type == 'unknown'
+  elseif b:sy.type == 'unknown'
+    let [ diff, b:sy.type ] = sy#repo#detect()
+    if b:sy.type == 'unknown'
       " no VCS found
       return
     endif
-    let g:sy[a:path].type = type
 
   " update signs
   else
-    let diff = sy#repo#get_diff_{g:sy[a:path].type}(a:path)[1]
+    let diff = sy#repo#get_diff_{b:sy.type}()[1]
     if empty(diff)
-      call sy#sign#remove_all(a:path)
+      call sy#sign#remove_all(b:sy.buffer)
       return
     endif
-    let g:sy[a:path].id_top = g:id_top
+    let b:sy.id_top = g:id_top
   endif
 
   if get(g:, 'signify_line_highlight')
@@ -82,52 +81,49 @@ function! sy#start(path) abort
       call sy#highlight#line_disable()
   endif
 
-  execute 'sign place 99999 line=1 name=SignifyPlaceholder file='. a:path
-  call sy#sign#remove_all(a:path)
+  execute 'sign place 99999 line=1 name=SignifyPlaceholder buffer='. b:sy.buffer
+  call sy#sign#remove_all(b:sy.buffer)
 
   if !g:signify_sign_overwrite
-    call sy#sign#get_others(a:path)
+    call sy#sign#get_others()
   endif
 
-  call sy#repo#process_diff(a:path, diff)
+  call sy#repo#process_diff(diff)
   sign unplace 99999
 
-  let g:sy[a:path].id_top = (g:id_top - 1)
+  let b:sy.id_top = (g:id_top - 1)
 endfunction
 
 " Function: #stop {{{1
-function! sy#stop(path) abort
-  if !has_key(g:sy, a:path)
+function! sy#stop(bnum) abort
+  let bvars = getbufvar(a:bnum, '', {})
+  if !has_key(bvars, 'sy')
     return
   endif
 
-  call sy#sign#remove_all(a:path)
+  call sy#sign#remove_all(a:bnum)
 
   silent! nunmap <buffer> ]c
   silent! nunmap <buffer> [c
 
   augroup signify
-    autocmd! * <buffer>
+    exe 'autocmd! * <buffer='. a:bnum . '>'
   augroup END
 endfunction
 
 " Function: #toggle {{{1
 function! sy#toggle() abort
-  if empty(g:sy_path)
+  if empty(b:sy.path)
     echomsg 'signify: I cannot sy empty buffers!'
     return
   endif
 
-  if has_key(g:sy, g:sy_path)
-    if g:sy[g:sy_path].active
-      call sy#stop(g:sy_path)
-      let g:sy[g:sy_path].active = 0
-      let g:sy[g:sy_path].stats = [-1, -1, -1]
-    else
-      let g:sy[g:sy_path].active = 1
-      call sy#start(g:sy_path)
-    endif
+  if b:sy.active
+    call sy#stop(b:sy.buffer)
+    let b:sy.active = 0
+    let b:sy.stats = [-1, -1, -1]
   else
-    call sy#start(g:sy_path)
+    let b:sy.active = 1
+    call sy#start(b:sy.path)
   endif
 endfunction

--- a/autoload/sy/debug.vim
+++ b/autoload/sy/debug.vim
@@ -4,15 +4,16 @@ scriptencoding utf-8
 
 " Function: #list_active_buffers {{{1
 function! sy#debug#list_active_buffers() abort
-  if empty(g:sy)
-    echomsg 'No active buffers!'
-    return
-  endif
+  for b in range(bufnr('$'))
+    if !buflisted(b) || empty(getbufvar(b, 'sy', {}))
+      continue
+    endif
 
-  for [path, stats] in items(g:sy)
+    let sy = copy(getbufvar(b, 'sy'))
+    let path = remove(sy, 'path')
     echo "\n". path ."\n". repeat('=', strlen(path))
-    for stat in sort(keys(stats))
-      echo printf("%20s  =  %s\n", stat, string(stats[stat]))
+    for stat in sort(keys(sy))
+      echo printf("%20s  =  %s\n", stat, string(sy[stat]))
     endfor
   endfor
 endfunction

--- a/autoload/sy/highlight.vim
+++ b/autoload/sy/highlight.vim
@@ -85,7 +85,7 @@ endfunction
 
 " Function: #line_toggle {{{1
 function! sy#highlight#line_toggle() abort
-  if !has_key(g:sy, g:sy_path)
+  if !exists('b:sy')
     echomsg 'signify: I cannot detect any changes!'
     return
   endif
@@ -96,5 +96,5 @@ function! sy#highlight#line_toggle() abort
     call sy#highlight#line_enable()
   endif
 
-  call sy#start(g:sy_path)
+  call sy#start(b:sy.path)
 endfunction

--- a/autoload/sy/jump.vim
+++ b/autoload/sy/jump.vim
@@ -4,32 +4,32 @@ scriptencoding utf-8
 
 " Function: #next_hunk {{{1
 function! sy#jump#next_hunk(count)
-  if !has_key(g:sy, g:sy_path)
+  if !exists('b:sy')
     echomsg 'signify: I cannot detect any changes!'
     return
   endif
 
   let lnum = line('.')
-  let hunks = filter(copy(g:sy[g:sy_path].hunks), 'v:val.start > lnum')
+  let hunks = filter(copy(b:sy.hunks), 'v:val.start > lnum')
   let hunk = get(hunks, a:count - 1, get(hunks, -1, {}))
 
   if !empty(hunk)
-    execute 'sign jump '. hunk.ids[0] .' file='. g:sy_path
+    execute 'sign jump '. hunk.ids[0] .' buffer='. b:sy.buffer
   endif
 endfunction
 
 " Function: #prev_hunk {{{1
 function! sy#jump#prev_hunk(count)
-  if !has_key(g:sy, g:sy_path)
+  if !exists('b:sy')
     echomsg 'signify: I cannot detect any changes!'
     return
   endif
 
   let lnum = line('.')
-  let hunks = filter(copy(g:sy[g:sy_path].hunks), 'v:val.start < lnum')
+  let hunks = filter(copy(b:sy.hunks), 'v:val.start < lnum')
   let hunk = get(hunks, 0 - a:count, get(hunks, 0, {}))
 
   if !empty(hunk)
-    execute 'sign jump '. hunk.ids[0] .' file='. g:sy_path
+    execute 'sign jump '. hunk.ids[0] .' buffer='. b:sy.buffer
   endif
 endfunction

--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -41,8 +41,8 @@ if empty(s:vcs_list)
 endif
 
 " Function: #detect {{{1
-function! sy#repo#detect(path) abort
-  let dir = fnamemodify(a:path, ':h')
+function! sy#repo#detect() abort
+  let dir = fnamemodify(b:sy.path, ':h')
 
   " Simple cache. If there is a registered VCS-controlled file in this
   " directory already, assume that this file is probably controlled by
@@ -56,7 +56,7 @@ function! sy#repo#detect(path) abort
   endif
 
   for type in s:vcs_list
-    let [istype, diff] = sy#repo#get_diff_{type}(a:path)
+    let [istype, diff] = sy#repo#get_diff_{type}()
     if istype
       return [ diff, type ]
     endif
@@ -66,9 +66,9 @@ function! sy#repo#detect(path) abort
 endfunction
 
 " Function: #get_diff_git {{{1
-function! sy#repo#get_diff_git(path) abort
+function! sy#repo#get_diff_git() abort
   let diffoptions = has_key(g:signify_diffoptions, 'git') ? g:signify_diffoptions.git : ''
-  let diff = system('cd '. sy#util#escape(fnamemodify(a:path, ':h')) .' && git diff --no-color --no-ext-diff -U0 '. diffoptions .' -- '. sy#util#escape(fnamemodify(a:path, ':t')))
+  let diff = system('cd '. sy#util#escape(fnamemodify(b:sy.path, ':h')) .' && git diff --no-color --no-ext-diff -U0 '. diffoptions .' -- '. sy#util#escape(fnamemodify(b:sy.path, ':t')))
 
   return v:shell_error ? [0, ''] : [1, diff]
 endfunction
@@ -76,9 +76,9 @@ endfunction
 " Function: #get_stat_git {{{1
 function! sy#repo#get_stat_git() abort
   let s:stats = []
-  let root  = finddir('.git', fnamemodify(g:sy_path, ':h') .';')
+  let root  = finddir('.git', fnamemodify(b:sy.path, ':h') .';')
   if empty(root)
-    echohl ErrorMsg | echomsg 'Cannot find the git root directory: '. g:sy_path | echohl None
+    echohl ErrorMsg | echomsg 'Cannot find the git root directory: '. b:sy.path | echohl None
     return
   endif
   let root   = fnamemodify(root, ':h')
@@ -105,73 +105,73 @@ function! sy#repo#get_stat_git() abort
 endfunction
 
 " Function: #get_diff_hg {{{1
-function! sy#repo#get_diff_hg(path) abort
+function! sy#repo#get_diff_hg() abort
   let diffoptions = has_key(g:signify_diffoptions, 'hg') ? g:signify_diffoptions.hg : ''
-  let diff = system('hg diff --nodates -U0 '. diffoptions .' -- '. sy#util#escape(a:path))
+  let diff = system('hg diff --nodates -U0 '. diffoptions .' -- '. sy#util#escape(b:sy.path))
 
   return v:shell_error ? [0, ''] : [1, diff]
 endfunction
 
 " Function: #get_diff_svn {{{1
-function! sy#repo#get_diff_svn(path) abort
+function! sy#repo#get_diff_svn() abort
   let diffoptions = has_key(g:signify_diffoptions, 'svn') ? g:signify_diffoptions.svn : ''
-  let diff = system('svn diff --diff-cmd '. s:difftool .' -x -U0 '. diffoptions .' -- '. sy#util#escape(a:path))
+  let diff = system('svn diff --diff-cmd '. s:difftool .' -x -U0 '. diffoptions .' -- '. sy#util#escape(b:sy.path))
 
   return v:shell_error ? [0, ''] : [1, diff]
 endfunction
 
 " Function: #get_diff_bzr {{{1
-function! sy#repo#get_diff_bzr(path) abort
+function! sy#repo#get_diff_bzr() abort
   let diffoptions = has_key(g:signify_diffoptions, 'bzr') ? g:signify_diffoptions.bzr : ''
-  let diff = system('bzr diff --using '. s:difftool .' --diff-options=-U0 '. diffoptions .' -- '. sy#util#escape(a:path))
+  let diff = system('bzr diff --using '. s:difftool .' --diff-options=-U0 '. diffoptions .' -- '. sy#util#escape(b:sy.path))
 
   return (v:shell_error =~ '[012]') ? [1, diff] : [0, '']
 endfunction
 
 " Function: #get_diff_darcs {{{1
-function! sy#repo#get_diff_darcs(path) abort
+function! sy#repo#get_diff_darcs() abort
   let diffoptions = has_key(g:signify_diffoptions, 'darcs') ? g:signify_diffoptions.darcs : ''
-  let diff = system('cd '. sy#util#escape(fnamemodify(a:path, ':h')) .' && darcs diff --no-pause-for-gui --diff-command="'. s:difftool .' -U0 %1 %2 '. diffoptions .'" -- '. sy#util#escape(a:path))
+  let diff = system('cd '. sy#util#escape(fnamemodify(b:sy.path, ':h')) .' && darcs diff --no-pause-for-gui --diff-command="'. s:difftool .' -U0 %1 %2 '. diffoptions .'" -- '. sy#util#escape(b:sy.path))
   return v:shell_error ? [0, ''] : [1, diff]
 endfunction
 
 " Function: #get_diff_fossil {{{1
-function! sy#repo#get_diff_fossil(path) abort
+function! sy#repo#get_diff_fossil() abort
   let diffoptions = has_key(g:signify_diffoptions, 'fossil') ? g:signify_diffoptions.fossil : ''
-  let diff = system('cd '. sy#util#escape(fnamemodify(a:path, ':h')) .' && fossil set diff-command "'. s:difftool .' -U 0" && fossil diff --unified -c 0 '. diffoptions .' -- '. sy#util#escape(a:path))
+  let diff = system('cd '. sy#util#escape(fnamemodify(b:sy.path, ':h')) .' && fossil set diff-command "'. s:difftool .' -U 0" && fossil diff --unified -c 0 '. diffoptions .' -- '. sy#util#escape(b:sy.path))
   return v:shell_error ? [0, ''] : [1, diff]
 endfunction
 
 " Function: #get_diff_cvs {{{1
-function! sy#repo#get_diff_cvs(path) abort
+function! sy#repo#get_diff_cvs() abort
   let diffoptions = has_key(g:signify_diffoptions, 'cvs') ? g:signify_diffoptions.cvs : ''
-  let diff = system('cd '. sy#util#escape(fnamemodify(a:path, ':h')) .' && cvs diff -U0 '. diffoptions .' -- '. sy#util#escape(fnamemodify(a:path, ':t')))
+  let diff = system('cd '. sy#util#escape(fnamemodify(b:sy.path, ':h')) .' && cvs diff -U0 '. diffoptions .' -- '. sy#util#escape(fnamemodify(b:sy.path, ':t')))
   return ((v:shell_error == 1) && (diff =~ '+++')) ? [1, diff] : [0, '']
 endfunction
 
 " Function: #get_diff_rcs {{{1
-function! sy#repo#get_diff_rcs(path) abort
+function! sy#repo#get_diff_rcs() abort
   let diffoptions = has_key(g:signify_diffoptions, 'rcs') ? g:signify_diffoptions.rcs : ''
-  let diff = system('rcsdiff -U0 '. diffoptions .' '. sy#util#escape(a:path) .' 2>/dev/null')
+  let diff = system('rcsdiff -U0 '. diffoptions .' '. sy#util#escape(b:sy.path) .' 2>/dev/null')
   return v:shell_error ? [0, ''] : [1, diff]
 endfunction
 
 " Function: #get_diff_accurev {{{1
-function! sy#repo#get_diff_accurev(path) abort
+function! sy#repo#get_diff_accurev() abort
   let diffoptions = has_key(g:signify_diffoptions, 'accurev') ? g:signify_diffoptions.accurev : ''
-  let diff = system('cd '. sy#util#escape(fnamemodify(a:path, ':h')) .' && accurev diff '. sy#util#escape(fnamemodify(a:path, ':t')) . ' -- -U0 '. diffoptions)
+  let diff = system('cd '. sy#util#escape(fnamemodify(b:sy.path, ':h')) .' && accurev diff '. sy#util#escape(fnamemodify(b:sy.path, ':t')) . ' -- -U0 '. diffoptions)
   return (v:shell_error != 1) ? [0, ''] : [1, diff]
 endfunction
 
 " Function: #get_diff_perforce {{{1
-function! sy#repo#get_diff_perforce(path) abort
+function! sy#repo#get_diff_perforce() abort
   let diffoptions = has_key(s:diffoptions, 'perforce') ? s:diffoptions.perforce : ''
-  let diff = system('env P4DIFF=diff p4 diff -dU0 '. diffoptions .' '. sy#util#escape(a:path))
+  let diff = system('env P4DIFF=diff p4 diff -dU0 '. diffoptions .' '. sy#util#escape(b:sy.path))
   return v:shell_error ? [0, ''] : [1, diff]
 endfunction
 
 " Function: #process_diff {{{1
-function! sy#repo#process_diff(path, diff) abort
+function! sy#repo#process_diff(diff) abort
   let added    = 0
   let deleted  = 0
   let modified = 0
@@ -201,8 +201,7 @@ function! sy#repo#process_diff(path, diff) abort
       while offset < new_count
         call add(signs, {
               \ 'type': 'SignifyAdd',
-              \ 'lnum': new_line + offset,
-              \ 'path': a:path })
+              \ 'lnum': new_line + offset })
         let offset += 1
       endwhile
 
@@ -218,13 +217,11 @@ function! sy#repo#process_diff(path, diff) abort
       if new_line == 0
         call add(signs, {
               \ 'type': 'SignifyDeleteFirstLine',
-              \ 'lnum': 1,
-              \ 'path': a:path })
+              \ 'lnum': 1 })
       else
         call add(signs, {
               \ 'type': (old_count > 9) ? 'SignifyDeleteMore' : 'SignifyDelete'. old_count,
-              \ 'lnum': new_line,
-              \ 'path': a:path })
+              \ 'lnum': new_line })
       endif
 
     " 2 lines changed:
@@ -242,8 +239,7 @@ function! sy#repo#process_diff(path, diff) abort
       while offset < new_count
         call add(signs, {
               \ 'type': 'SignifyChange',
-              \ 'lnum': new_line + offset,
-              \ 'path': a:path })
+              \ 'lnum': new_line + offset })
         let offset += 1
       endwhile
     else
@@ -267,15 +263,13 @@ function! sy#repo#process_diff(path, diff) abort
         while offset < (new_count - 1)
           call add(signs, {
                 \ 'type': 'SignifyChange',
-                \ 'lnum': new_line + offset,
-                \ 'path': a:path })
+                \ 'lnum': new_line + offset })
           let offset += 1
         endwhile
 
         call add(signs, {
               \ 'type': (removed > 9) ? 'SignifyChangeDeleteMore' : 'SignifyChangeDelete'. removed,
-              \ 'lnum': new_line,
-              \ 'path': a:path })
+              \ 'lnum': new_line })
 
       " lines changed and added:
 
@@ -293,16 +287,14 @@ function! sy#repo#process_diff(path, diff) abort
         while offset < old_count
           call add(signs, {
                 \ 'type': 'SignifyChange',
-                \ 'lnum': new_line + offset,
-                \ 'path': a:path })
+                \ 'lnum': new_line + offset })
           let offset += 1
         endwhile
 
         while offset < new_count
           call add(signs, {
                 \ 'type': 'SignifyAdd',
-                \ 'lnum': new_line + offset,
-                \ 'path': a:path })
+                \ 'lnum': new_line + offset })
           let offset += 1
         endwhile
       endif
@@ -311,14 +303,14 @@ function! sy#repo#process_diff(path, diff) abort
     call sy#sign#set(signs)
   endfor
 
-  let g:sy[g:sy_path].stats = [added, modified, deleted]
+  let b:sy.stats = [added, modified, deleted]
 endfunction
 
 " Function: #get_stats {{{1
 function! sy#repo#get_stats() abort
-  if !exists('g:sy_path') || !has_key(g:sy, g:sy_path)
+  if !exists('b:sy') || !has_key(b:sy, 'stats')
     return [-1, -1, -1]
   endif
 
-  return g:sy[g:sy_path].stats
+  return b:sy.stats
 endfunction

--- a/autoload/sy/sign.vim
+++ b/autoload/sy/sign.vim
@@ -3,14 +3,14 @@
 scriptencoding utf-8
 
 " Function: #get_others {{{1
-function! sy#sign#get_others(path) abort
+function! sy#sign#get_others() abort
   let s:other_signs_line_numbers = {}
 
   let lang = v:lang
   silent! execute 'language C'
 
   redir => signlist
-    silent! execute 'sign place file='. a:path
+    silent! execute 'sign place buffer='. b:sy.buffer
   redir END
 
   for line in filter(split(signlist, '\n'), 'v:val =~ "^\\s\\+line"')
@@ -32,26 +32,27 @@ function! sy#sign#set(signs)
     endif
 
     call add(hunk.ids, g:id_top)
-    execute 'sign place' g:id_top 'line='. sign.lnum 'name='. sign.type 'file='. sign.path
+    execute 'sign place' g:id_top 'line='. sign.lnum 'name='. sign.type 'buffer='. b:sy.buffer
 
     let g:id_top += 1
   endfor
 
-  call add(g:sy[sign.path].hunks, hunk)
+  call add(b:sy.hunks, hunk)
 endfunction
 
 " Function: #remove_all {{{1
-function! sy#sign#remove_all(path) abort
+function! sy#sign#remove_all(bnum) abort
+  let sy = getbufvar(a:bnum, 'sy')
   if g:signify_sign_overwrite
-    execute 'sign unplace * file='. a:path
+    execute 'sign unplace * buffer='. sy.buffer
   else
-    for hunk in g:sy[a:path].hunks
+    for hunk in sy.hunks
       for id in hunk.ids
         execute 'sign unplace' id
       endfor
     endfor
   endif
 
-  let g:sy[a:path].hunks = []
-  let g:sy[a:path].stats = [0, 0, 0]
+  let sy.hunks = []
+  let sy.stats = [0, 0, 0]
 endfunction

--- a/plugin/signify.vim
+++ b/plugin/signify.vim
@@ -7,47 +7,39 @@ if exists('g:loaded_signify') || !has('signs') || &cp
 endif
 let g:loaded_signify = 1
 
-" Init: values {{{1
-let g:sy = {}
-
 " Init: autocmds {{{1
 augroup signify
   autocmd!
 
   autocmd VimEnter             * call sy#highlight#setup()
-  autocmd BufRead,BufEnter     * let g:sy_path = resolve(expand('<afile>:p'))
-  autocmd BufRead,BufWritePost * call sy#start(g:sy_path)
+  autocmd BufRead,BufEnter     * let b:sy_path = resolve(expand('<afile>:p'))
+  autocmd BufRead,BufWritePost * call sy#start(b:sy_path)
 
-  autocmd BufDelete *
-        \ let path = resolve(expand('<afile>:p')) |
-        \ call sy#stop(path) |
-        \ if has_key(g:sy, path) |
-        \   call remove(g:sy, path) |
-        \ endif
+  autocmd BufDelete * call sy#stop(expand('<abuf>'))
 
   if get(g:, 'signify_update_on_bufenter')
     autocmd BufEnter * nested
-          \ if has_key(g:sy, g:sy_path) && g:sy[g:sy_path].active && &modified |
+          \ if exists('b:sy') && b:sy.active && &modified |
           \   write |
           \ endif
   endif
 
   if get(g:, 'signify_cursorhold_normal')
     autocmd CursorHold * nested
-          \ if has_key(g:sy, g:sy_path) && g:sy[g:sy_path].active && &modified |
+          \ if exists('b:sy') && b:sy.active && &modified |
           \   write |
           \ endif
   endif
 
   if get(g:, 'signify_cursorhold_insert')
     autocmd CursorHoldI * nested
-          \ if has_key(g:sy, g:sy_path) && g:sy[g:sy_path].active && &modified |
+          \ if exists('b:sy') && b:sy.active && &modified |
           \   write |
           \ endif
   endif
 
   if get(g:, 'signify_update_on_focusgained') && !has('gui_win32')
-    autocmd FocusGained * call sy#start(g:sy_path)
+    autocmd FocusGained * if exists('b:sy') | call sy#start(b:sy.path) | endif
   endif
 augroup END
 


### PR DESCRIPTION
While I was under the foolish impression that #88 was due to Sy placing signs using `file=` instead of `buffer=`, I refactored Sy to store its data in `b:sy` instead of `g:sy`.  Although it didn't solve the original problem, it has simplified certain aspects of the code.

I figured I'd at least toss this over the wall to see what you think.
