### PR TITLE
Use 1-based indexing for buffer ranges

### DIFF
--- a/autoload/sy/debug.vim
+++ b/autoload/sy/debug.vim
@@ -4,7 +4,7 @@ scriptencoding utf-8
 
 " Function: #list_active_buffers {{{1
 function! sy#debug#list_active_buffers() abort
-  for b in range(0, bufnr('$'))
+  for b in range(1, bufnr('$'))
     if !buflisted(b) || empty(getbufvar(b, 'sy'))
       continue
     endif


### PR DESCRIPTION
`:SyDebug` is displaying info if an alternate buffer is set.  This
occurs because a buffer number of 0 represents the alternate buffer.
Using a 1-based range in sy#debug#list_active_buffers fixes this.

Signed-off-by: James McCoy vega.james@gmail.com
