### PR TITLE
Disable evaluation of buffers during a 'vimgrep'

### DIFF
--- a/autoload/sy.vim
+++ b/autoload/sy.vim
@@ -18,6 +18,9 @@ sign define SignifyPlaceholder text=. texthl=SignifySignChange linehl=
 
 " Function: #start {{{1
 function! sy#start(path) abort
+  if g:signify_locked
+    return
+  endif
   if &diff
         \ || !filereadable(a:path)
         \ || (exists('g:signify_skip_filetype') && has_key(g:signify_skip_filetype, &ft))

--- a/plugin/signify.vim
+++ b/plugin/signify.vim
@@ -7,6 +7,7 @@ if exists('g:loaded_signify') || !has('signs') || &cp
 endif
 let g:loaded_signify = 1
 
+let g:signify_locked = 0
 " Init: autocmds {{{1
 augroup signify
   autocmd!
@@ -15,6 +16,10 @@ augroup signify
   autocmd BufRead,BufEnter     * let b:sy_path = resolve(expand('<afile>:p'))
   autocmd BufRead,BufWritePost * call sy#start(b:sy_path)
   autocmd BufDelete            * call sy#stop(expand('<abuf>'))
+
+  " Don't signify during vimgrep runs
+  autocmd QuickFixCmdPre *vimgrep* let g:signify_locked = 1
+  autocmd QuickFixCmdPost *vimgrep* let g:signify_locked = 0
 
   if get(g:, 'signify_update_on_bufenter')
     autocmd BufEnter * nested


### PR DESCRIPTION
When using 'vimgrep', for each file that is being evaluated, a BufRead event is
fired, cuasing vim-sifnify to evaluate the buffer by calling 'sy#start'.

By using a lock we can reduce the time spent 'vimgrepping' significantly. E.g.
In one of my runs it went from 30+ seconds to < 1 second.

Note that this issue could also have been solved with the autocmd:

```
:noautocmd vim /query/ **/*.ext
```

Yet this has the negative effect of disabling colouring and it is more work to
type.

This fix is based on the comment from this thread:
http://vim.1045645.n5.nabble.com/vimgrep-and-BufRead-td1177993.html

And was taken from the MRU plugin, also referenced in the above thread:
https://github.com/vim-scripts/mru.vim/commit/3e95376cc9f44e4dcb82e35d783ea3c79f1ae6c5

This fix probably also makes #91 less likely to occur.
