### PR TITLE
Restore behavior of using _> for SignifyDeleteMore signs

### DIFF
--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -4,6 +4,7 @@ scriptencoding utf-8
 
 " Init: values {{{1
 
+let s:sign_delete = get(g:, 'signify_sign_delete', '_')
 if !exists('g:signify_diffoptions')
   let g:signify_diffoptions = {}
 endif
@@ -218,11 +219,16 @@ function! sy#repo#process_diff(diff) abort
         call add(signs, {
               \ 'type': 'SignifyDeleteFirstLine',
               \ 'lnum': 1 })
+      elseif old_count <= 99
+        call add(signs, {
+              \ 'type': 'SignifyDelete'.old_count,
+              \ 'text': substitute(s:sign_delete . old_count, '.*\ze..$', '', ''),
+              \ 'lnum': new_line })
       else
         call add(signs, {
-              \ 'type': 'SignifyDelete',
-              \ 'count': old_count,
-              \ 'lnum': new_line })
+              \ 'type': 'SignifyDeleteMore',
+              \ 'lnum': new_line,
+              \ 'text': s:sign_delete . '>' })
       endif
 
     " 2 lines changed:

--- a/autoload/sy/sign.vim
+++ b/autoload/sy/sign.vim
@@ -3,7 +3,6 @@
 scriptencoding utf-8
 
 " Init: values {{{1
-let s:sign_delete = get(g:, 'signify_sign_delete', '_')
 let s:delete_highlight = ['', 'SignifyLineDelete']
 
 " Function: #get_others {{{1
@@ -42,10 +41,9 @@ function! sy#sign#set(signs)
     endif
 
     call add(hunk.ids, g:id_top)
-    if sign.type == 'SignifyDelete'
-      let sygn = (sign.count < 10) ? (s:sign_delete . sign.count) : string(sign.count)[-2:]
-      execute 'sign define SignifyDelete'. sign.count .' text='. sygn .' texthl=SignifySignDelete linehl='. s:delete_highlight[g:signify_line_highlight]
-      execute 'sign place' g:id_top 'line='. sign.lnum 'name='. sign.type . sign.count 'buffer='. b:sy.buffer
+    if sign.type =~# 'SignifyDelete'
+      execute 'sign define '. sign.type .' text='. sign.text .' texthl=SignifySignDelete linehl='. s:delete_highlight[g:signify_line_highlight]
+      execute 'sign place' g:id_top 'line='. sign.lnum 'name='. sign.type 'buffer='. b:sy.buffer
     else
       execute 'sign place' g:id_top 'line='. sign.lnum 'name='. sign.type 'buffer='. b:sy.buffer
     endif

--- a/doc/signify.txt
+++ b/doc/signify.txt
@@ -68,8 +68,8 @@ Sign explanation:~
     `!`     This line was modified.
 
     `_1`    The number of deleted lines below this sign. If the number is larger
-    `99`    than 9, the `_` will be omitted. For numbers larger than 99 the
-            counter will simply overflow and start at `00` again.
+    `99`    than 9, the `_` will be omitted. For numbers larger than 99, `_>`
+    `_>`    will be shown instead.
 
     `!1`    This line was modified and a number of lines below were deleted.
     `!>`    It is a combination of `!` and `_`. If the number is larger than 9,


### PR DESCRIPTION
I think this would be the proper way to fix #109.
