### PR TITLE
Fix sy#sign#get_others() set locale to 'C' on Windows chinese version

### DIFF
--- a/autoload/sy/sign.vim
+++ b/autoload/sy/sign.vim
@@ -10,7 +10,7 @@ function! sy#sign#get_others() abort
   let s:other_signs_line_numbers = {}
 
   let lang = v:lang
-  silent! execute 'language C'
+  silent! execute 'language message C'
 
   redir => signlist
     silent! execute 'sign place buffer='. b:sy.buffer
@@ -27,7 +27,7 @@ function! sy#sign#get_others() abort
     let s:other_signs_line_numbers[lnum] = 1
   endfor
 
-  silent! execute 'language' lang
+  silent! execute 'language message' lang
 endfunction
 
 " Function: #set {{{1


### PR DESCRIPTION
In the Chinese version windows, "v: lang" is "zh_CN", but execute ": language zh_CN" will fail, must use. ":language chinese_china" to change the locale.

Using the ":language message zh_CN" everything is fine.
