### PR TITLE
Fixed error toggling in empty buffers

### DIFF
--- a/autoload/sy.vim
+++ b/autoload/sy.vim
@@ -114,7 +114,10 @@ endfunction
 
 " Function: #toggle {{{1
 function! sy#toggle() abort
-  if empty(b:sy.path)
+  if !exists('b:sy')
+    echomsg 'signify: I cannot sy empty buffers!'
+    return
+  elseif empty(b:sy.path)
     echomsg 'signify: I cannot sy empty buffers!'
     return
   endif


### PR DESCRIPTION
I only started running into this error since vim upgraded to version 7.4.274 last night, so it could be a result of new/changed behaviour if you don't run into it too, or maybe I simply managed to avoid it up until now; either way, I figured it was worth mentioning just in case.

The issue occurred in an unsaved buffer when trying to toggle vim-signify, and it would result in an error message complaining about b:sy not existing when trying to test and see if it's empty. To fix the issue, I simply added a check to see if b:sy exists that prints an error and returns exactly like what happens when b:sy is empty, and if it does exist, it then checks to see if it's empty and so on just like before.

I didn't bother testing to see if the second check becomes redundant with the addition of the first because it seems possible that older versions of Vim might work with the old implementation, and that switching exclusively to the new one would then break those older versions. If that isn't the case, and this was simply a bug that hadn't been caught, it's probably worth removing the second in favour of the microscopic performance boost that will result :)
