### PR TITLE
Add finer grained control over signs and highlights

### DIFF
--- a/autoload/sy/highlight.vim
+++ b/autoload/sy/highlight.vim
@@ -6,56 +6,60 @@ scriptencoding utf-8
 let s:sign_add               = get(g:, 'signify_sign_add',               '+')
 let s:sign_delete_first_line = get(g:, 'signify_sign_delete_first_line', '‾')
 let s:sign_change            = get(g:, 'signify_sign_change',            '!')
+let s:sign_changedelete      = get(g:, 'signify_sign_changedelete',      s:sign_change)
 
 " Function: #setup {{{1
 function! sy#highlight#setup() abort
-  highlight default link SignifyLineAdd    DiffAdd
-  highlight default link SignifyLineChange DiffChange
-  highlight default link SignifyLineDelete DiffDelete
+  highlight default link SignifyLineAdd             DiffAdd
+  highlight default link SignifyLineChange          DiffChange
+  highlight default link SignifyLineChangeDelete    SignifyLineChange
+  highlight default link SignifyLineDelete          DiffDelete
+  highlight default link SignifyLineDeleteFirstLine SignifyLineDelete
 
-  highlight default link SignifySignAdd    DiffAdd
-  highlight default link SignifySignChange DiffChange
-  highlight default link SignifySignDelete DiffDelete
+  highlight default link SignifySignAdd             DiffAdd
+  highlight default link SignifySignChange          DiffChange
+  highlight default link SignifySignChangeDelete    SignifySignChange
+  highlight default link SignifySignDelete          DiffDelete
+  highlight default link SignifySignDeleteFirstLine SignifySignDelete
 endfunction
 
 " Function: #line_enable {{{1
 function! sy#highlight#line_enable() abort
   execute 'sign define SignifyAdd text='. s:sign_add ' texthl=SignifySignAdd linehl=SignifyLineAdd'
 
-  execute 'sign define SignifyChange text='. s:sign_change ' texthl=SignifySignChange linehl=SignifyLineChange'
-  execute 'sign define SignifyChangeDelete1 text='. s:sign_change .'1 texthl=SignifySignChange linehl=SignifyLineChange'
-  execute 'sign define SignifyChangeDelete2 text='. s:sign_change .'2 texthl=SignifySignChange linehl=SignifyLineChange'
-  execute 'sign define SignifyChangeDelete3 text='. s:sign_change .'3 texthl=SignifySignChange linehl=SignifyLineChange'
-  execute 'sign define SignifyChangeDelete4 text='. s:sign_change .'4 texthl=SignifySignChange linehl=SignifyLineChange'
-  execute 'sign define SignifyChangeDelete5 text='. s:sign_change .'5 texthl=SignifySignChange linehl=SignifyLineChange'
-  execute 'sign define SignifyChangeDelete6 text='. s:sign_change .'6 texthl=SignifySignChange linehl=SignifyLineChange'
-  execute 'sign define SignifyChangeDelete7 text='. s:sign_change .'7 texthl=SignifySignChange linehl=SignifyLineChange'
-  execute 'sign define SignifyChangeDelete8 text='. s:sign_change .'8 texthl=SignifySignChange linehl=SignifyLineChange'
-  execute 'sign define SignifyChangeDelete9 text='. s:sign_change .'9 texthl=SignifySignChange linehl=SignifyLineChange'
-  execute 'sign define SignifyChangeDeleteMore text='. s:sign_change .'> texthl=SignifySignChange linehl=SignifyLineChange'
+  execute 'sign define SignifyChange text='. s:sign_change .' texthl=SignifySignChange linehl=SignifyLineChange'
 
-  execute 'sign define SignifyRemoveFirstLine text='. s:sign_delete_first_line ' texthl=SignifySignDelete linehl=SignifyLineDelete'
+  let changedelete_suffixes = split('123456789>','\zs')
+  for suffix in changedelete_suffixes
+    " append number suffix to sign text
+    let text = s:sign_changedelete.suffix
+    " sign text can only be 2 characters long
+    let text = text[:1]
+
+    let sign_name = suffix == '>' ? 'More' : suffix
+    execute 'sign define SignifyChangeDelete'. sign_name .' text='. text .' texthl=SignifySignChangeDelete linehl=SignifyLineChangeDelete'
+  endfor
+
+  execute 'sign define SignifyRemoveFirstLine text='. s:sign_delete_first_line ' texthl=SignifySignDelete linehl=SignifyLineDeleteFirstLine'
 
   let g:signify_line_highlight = 1
 endfunction
 
 " Function: #line_disable {{{1
 function! sy#highlight#line_disable() abort
-  execute 'sign define SignifyAdd text='. s:sign_add ' texthl=SignifySignAdd linehl='
+  execute 'sign define SignifyAdd text='. s:sign_add .' texthl=SignifySignAdd linehl='
 
-  execute 'sign define SignifyChange text='. s:sign_change ' texthl=SignifySignChange linehl='
-  execute 'sign define SignifyChangeDelete1 text='. s:sign_change .'1 texthl=SignifySignChange linehl='
-  execute 'sign define SignifyChangeDelete2 text='. s:sign_change .'2 texthl=SignifySignChange linehl='
-  execute 'sign define SignifyChangeDelete3 text='. s:sign_change .'3 texthl=SignifySignChange linehl='
-  execute 'sign define SignifyChangeDelete4 text='. s:sign_change .'4 texthl=SignifySignChange linehl='
-  execute 'sign define SignifyChangeDelete5 text='. s:sign_change .'5 texthl=SignifySignChange linehl='
-  execute 'sign define SignifyChangeDelete6 text='. s:sign_change .'6 texthl=SignifySignChange linehl='
-  execute 'sign define SignifyChangeDelete7 text='. s:sign_change .'7 texthl=SignifySignChange linehl='
-  execute 'sign define SignifyChangeDelete8 text='. s:sign_change .'8 texthl=SignifySignChange linehl='
-  execute 'sign define SignifyChangeDelete9 text='. s:sign_change .'9 texthl=SignifySignChange linehl='
-  execute 'sign define SignifyChangeDeleteMore text='. s:sign_change .'> texthl=SignifySignChange linehl='
+  execute 'sign define SignifyChange text='. s:sign_change .' texthl=SignifySignChange linehl='
+  let changedelete_suffixes = split('123456789>','\zs')
+  for suffix in changedelete_suffixes
+    let text = s:sign_changedelete.suffix
+    let text = text[:1]
 
-  execute 'sign define SignifyRemoveFirstLine text='. s:sign_delete_first_line ' texthl=SignifySignDelete linehl='
+    let sign_name = suffix == '>' ? 'More' : suffix
+    execute 'sign define SignifyChangeDelete'. sign_name .' text='. text .' texthl=SignifySignChangeDelete linehl='
+  endfor
+
+  execute 'sign define SignifyRemoveFirstLine text='. s:sign_delete_first_line ' texthl=SignifySignDeleteFirstLine linehl='
 
   let g:signify_line_highlight = 0
 endfunction

--- a/autoload/sy/sign.vim
+++ b/autoload/sy/sign.vim
@@ -3,8 +3,9 @@
 scriptencoding utf-8
 
 " Init: values {{{1
-let s:sign_delete      = get(g:, 'signify_sign_delete', '_')
-let s:delete_highlight = ['', 'SignifyLineDelete']
+let s:sign_delete_use_count = get(g:, 'signify_sign_delete_use_count', 1)
+let s:sign_delete           = get(g:, 'signify_sign_delete', '_')
+let s:delete_highlight      = ['', 'SignifyLineDelete']
 
 " Function: #get_next_id {{{1
 function! sy#sign#get_next_id() abort
@@ -93,9 +94,15 @@ function! sy#sign#process_diff(diff) abort
       if new_line == 0
         call add(ids, s:add_sign(1, 'SignifyRemoveFirstLine'))
       elseif old_count <= 99
-        call add(ids, s:add_sign(new_line, 'SignifyDelete'. old_count, substitute(s:sign_delete . old_count, '.*\ze..$', '', '')))
+        if s:sign_delete_use_count
+          let text = substitute(s:sign_delete . old_count, '.*\ze..$', '', '')
+        else
+          let text = s:sign_delete
+        endif
+        call add(ids, s:add_sign(new_line, 'SignifyDelete'. old_count, text))
       else
-        call add(ids, s:add_sign(new_line, 'SignifyDeleteMore', s:sign_delete .'>'))
+        let text = s:sign_delete_use_count ? s:sign_delete.'>' : s:sign_delete
+        call add(ids, s:add_sign(new_line, 'SignifyDeleteMore', text))
       endif
 
     " 2 lines changed:

--- a/doc/signify.txt
+++ b/doc/signify.txt
@@ -100,7 +100,9 @@ All available options:~
     |g:signify_sign_delete_first_line|
     |g:signify_sign_delete|
     |g:signify_sign_change|
+    |g:signify-option-sign_changedelete|
     |g:signify_sign_add|
+    |g:signify-option-sign_delete_use_count|
     |g:signify_cursorhold_normal|
     |g:signify_cursorhold_insert|
     |g:signify_difftool|
@@ -217,18 +219,27 @@ Update signs when Vim gains focus.
 Enable line highlighting in addition to using signs by default.
 
 ------------------------------------------------------------------------------
-                                              *g:signify_sign_delete_first_line*
-                                              *g:signify_sign_delete*
-                                              *g:signify_sign_change*
-                                              *g:signify_sign_add*
+                                            *g:signify_sign_delete_first_line*
+                                            *g:signify_sign_delete*
+                                            *g:signify-option-sign_changedelete*
+                                            *g:signify_sign_add*
 >
     let g:signify_sign_add               = '+'
     let g:signify_sign_change            = '!'
+    let g:signify_sign_changedelete      = g:signify_sign_change
     let g:signify_sign_delete            = '_'
     let g:signify_sign_delete_first_line = '‾'
 <
 The sign to use if a line was added, deleted or changed or a combination of
 these.
+
+------------------------------------------------------------------------------
+                                         *signify-option-sign_delete_use_count*
+>
+    let g:signify_sign_delete_use_count  = 1
+<
+Show the number of deleted lines in the sign column. When disabled, only the
+text defined by |signify-option-sign_delete| will be shown.
 
 ------------------------------------------------------------------------------
                                                    *g:signify_cursorhold_normal*
@@ -286,13 +297,17 @@ This plugin defines highlighting groups for two different places: for lines
 and signs. Per default these don't really exist but are linked to the standard
 highlighting groups: DiffAdd, DiffChange, DiffDelete:
 >
-    highlight link SignifyLineAdd    DiffAdd
-    highlight link SignifyLineChange DiffChange
-    highlight link SignifyLineDelete DiffDelete
+    highlight link SignifyLineAdd             DiffAdd
+    highlight link SignifyLineChange          DiffChange
+    highlight link SignifyLineDelete          DiffDelete
+    highlight link SignifyLineChangeDelete    SignifyLineChange
+    highlight link SignifyLineDeleteFirstLine SignifyLineDelete
 
-    highlight link SignifySignAdd    DiffAdd
-    highlight link SignifySignChange DiffChange
-    highlight link SignifySignDelete DiffDelete
+    highlight link SignifySignAdd             DiffAdd
+    highlight link SignifySignChange          DiffChange
+    highlight link SignifySignDelete          DiffDelete
+    highlight link SignifySignChangeDelete    SignifySignChange
+    highlight link SignifySignDeleteFirstLine SignifySignDelete
 <
 Thus if you do not want to change the standard highlighting groups, but want
 different colors for either your signs or lines, you can define one of these 6


### PR DESCRIPTION
I wanted to be able to customize signify in a way that wasn't possible with the current set of options.  This commit adds 2 new options and 2 new highlight groups.

Specifically, we can now
1.  differentiate between changes, deletes AND signs that have both
   with the `signify_sign_changedelete` option.
2.  disable showing the number of deleted lines in the sign column with
   the `signify_sign_delete_use_count` option.
3.  highlight lines with changes and deletes specifically with the
   `SignifySignChangeDelete` highlight group.
4.  highlight the first line differently with the
   `SignifySignDeleteFirstLine` highlight group.

All of these default to existing settings/highlight groups, so everything should continue working the way it does now.

For those that are curious, I wanted to configure signify to show no symbols in the sign column, and to just use the highlight groups to give me all the information I needed.  I am able to achieve that now with the following settings and the Solarized colorscheme:

```
let g:signify_sign_add = "\<Char-0xa0>\<Char-0xa0>"
let g:signify_sign_change = "\<Char-0xa0>\<Char-0xa0>"
let g:signify_sign_changedelete = "__"
let g:signify_sign_delete = "__"
let g:signify_sign_delete_first_line = "‾‾"
let g:signify_sign_delete_use_count = 0

hi SignifySignDelete term=bold,underline cterm=bold,underline ctermfg=1 ctermbg=12
hi SignifySignDeleteFirstLine ctermfg=1 ctermbg=12
hi SignifySignChangeDelete term=bold,underline cterm=bold,underline ctermfg=1 ctermbg=3
```
