### PR TITLE
Update signs both on FocusGained and FocusLost

### DIFF
--- a/autoload/sy/util.vim
+++ b/autoload/sy/util.vim
@@ -41,3 +41,10 @@ function! sy#util#run_in_dir(dir, cmd) abort
 
   return ret
 endfunction
+
+" Function: #refresh_windows {{{1
+function! sy#util#refresh_windows() abort
+  let winnr = winnr()
+  windo if exists('b:sy') | call sy#start() | endif
+  execute winnr .'wincmd w'
+endfunction

--- a/doc/signify.txt
+++ b/doc/signify.txt
@@ -34,6 +34,7 @@ TOC                                                           *signify-contents*
   COMMANDS ....................... |signify-commands|
   MAPPINGS ....................... |signify-mappings|
   OBJECTS ........................ |signify-objects|
+  FUNCTIONS ...................... |signify-functions|
   COLORS ......................... |signify-colors|
 
 ==============================================================================
@@ -96,7 +97,7 @@ All available options:~
     |g:signify_skip_filetype|
     |g:signify_skip_filename|
     |g:signify_update_on_bufenter|
-    |g:signify_update_on_focus|
+    |g:signify_update_on_focusgained|
     |g:signify_line_highlight|
     |g:signify_sign_add|
     |g:signify_sign_delete|
@@ -209,11 +210,11 @@ Update signs when entering a buffer that was modified.
 NOTE: This also saves the buffer to disk!
 
 ------------------------------------------------------------------------------
-                                                     *g:signify_update_on_focus*
+                                               *g:signify_update_on_focusgained*
 >
-    let g:signify_update_on_focus = 0
+    let g:signify_update_on_focusgained = 0
 <
-Update signs when Vim gains/loses focus.
+Update signs when Vim gains focus.
 
 ------------------------------------------------------------------------------
                                                       *g:signify_line_highlight*
@@ -370,5 +371,18 @@ For Unix people there is a small script, showcolors.bash, in the repo that
 shows all 256 colors available to the terminal. That makes picking the right
 numbers much easier.
 
+==============================================================================
+FUNCTIONS                                                    *signify-functions*
+
+Signify exposes some functions which you can use to customize its behavior.
+
+------------------------------------------------------------------------------
+sy#util#refresh_windows()                            *sy#util#refresh_windows()*
+
+This function updates signs for all windows. For example, to update signs when
+Vim loses focus, you can add autocommand:
+>
+    autocmd FocusLost * call sy#util#refresh_windows()
+<
 ==============================================================================
 vim: tw=78

--- a/plugin/signify.vim
+++ b/plugin/signify.vim
@@ -30,8 +30,8 @@ augroup signify
     autocmd CursorHoldI * nested call s:save()
   endif
 
-  if get(g:, 'signify_update_on_focus') && !has('gui_win32')
-    autocmd FocusGained,FocusLost * call s:refresh_windows()
+  if get(g:, 'signify_update_on_focusgained') && !has('gui_win32')
+    autocmd FocusGained * call sy#util#refresh_windows()
   endif
 augroup END
 
@@ -100,13 +100,6 @@ function! s:save()
   if exists('b:sy') && b:sy.active && &modified
     write
   endif
-endfunction
-
-" Function: refresh_windows {{{1
-function! s:refresh_windows() abort
-  let winnr = winnr()
-  windo if exists('b:sy') | call sy#start() | endif
-  execute winnr .'wincmd w'
 endfunction
 
 " Function: hunk_text_object {{{1


### PR DESCRIPTION
This pull request changes `g:signify_update_on_focusgained` to `g:signify_update_on_focus` which refreshes signs both on `FocusGained` and `FocusLost`. I think it makes sense to do it since unfocused MacVim still shows signs which might be confusing.

On the other hand, it might be undesired behavior. In this case I think it might make sense to expose public API so users could add their own autocommands. I can do this if that's preferrable.
