### PR TITLE
Escape 2>&1 in the p4 detect.  On Linux/Gvim, this was causing an error.

### DIFF
--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -163,7 +163,7 @@ endfunction
 " Function: #get_diff_perforce {{{1
 function! sy#repo#get_diff_perforce() abort
   let diffoptions = has_key(g:signify_diffoptions, 'perforce') ? g:signify_diffoptions.perforce : ''
-  let diff = system('p4 info 2>&1 >' . sy#util#devnull() . ' && env P4DIFF=diff p4 diff -dU0 '. diffoptions .' '. sy#util#escape(b:sy.path))
+  let diff = system(sy#util#escape('p4 info 2>&1 >') . sy#util#devnull() . ' && env P4DIFF=diff p4 diff -dU0 '. diffoptions .' '. sy#util#escape(b:sy.path))
   return v:shell_error ? [0, ''] : [1, diff]
 endfunction
 


### PR DESCRIPTION
Wrapped the p4 info command in a sy#util#escape call and the "could not open file" error went away.