### PR TITLE
Fix shell redirection when detecting perforce

### DIFF
--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -209,7 +209,9 @@ let s:vcs_cmds = {
       \ 'cvs':      'cvs diff -U0 -- %f',
       \ 'rcs':      'rcsdiff -U0 %f 2>%n',
       \ 'accurev':  'accurev diff %f -- -U0',
-      \ 'perforce': 'p4 info >%n 2>&1 && env P4DIFF=%d p4 diff -dU0 %f',
+      \ 'perforce': 'p4 info '
+      \              . sy#util#shell_redirect('%n')
+      \              . ' && env P4DIFF=%d p4 diff -dU0 %f',
       \ }
 
 if exists('g:signify_vcs_cmds')

--- a/autoload/sy/util.vim
+++ b/autoload/sy/util.vim
@@ -56,3 +56,16 @@ function! sy#util#hunk_text_object(emptylines) abort
   endif
 endfunction
 
+" Function: #shell_redirect {{{1
+function! sy#util#shell_redirect( path ) abort
+  " if shellredir contains a %s it is replaced with the path
+  " otherwise, just append it (from :help shellredir:
+  "   The name of the temporary file can be represented by "%s" if necessary
+  "   (the file name is appended automatically if no %s appears in the value
+  "   of this option)
+  if &shellredir =~ '\C%s'
+    return substitute(&shellredir, '\C%s', a:path, "g")
+  else
+    return &shellredir . ' ' . a:path
+  endif
+endfunction


### PR DESCRIPTION
Previously, when using *nix csh-like (or probably ksh-like) shells, perforce
detection would fail with E484. This was due to hard-coded bash-like
redirection.

This change obeys the vim `shellredir` option when detecting perforce.

In relation to https://github.com/mhinz/vim-signify/issues/165

Tested in `csh` and `bash` on linux and via `git bash` on windows. 

bash:
```
p4 info >/dev/null 2>&1 && env P4DIFF='diff' p4 diff -dU0 '/home/clean_test_bash/<snip>.
php'
===========================================================================================================
====
/home/clean_test_bash/<snip> - file(s) not opened on this client.
```

csh:
```
p4 info >& /dev/null && env P4DIFF='diff' p4 diff -dU0 '<snip>'
===================================================================================
==================================================
==== //depot/<snip>#8 - <snip> ====
--- /tmp/tmp.52534.8    2015-07-28 14:39:03.934024741 +0100
+++ <snip>
2015-07-28 11:29:47.569403000 +0100
@@ -235,0 +236,17 @@
... diffs here
```

When testing with non-command line on windows, I get this, but i don't think that is a new problem?
```
p4 info >NUL 2>&1 && env P4DIFF="diff" p4 diff -dU0 "p:\work\perforce-all\<snip>"
================================================================================
============================================================
'env' is not recognized as an internal or external command,
operable program or batch file.
```