### PR TITLE
Added SignifyDisable and SignifyEnable commands

### DIFF
--- a/autoload/sy.vim
+++ b/autoload/sy.vim
@@ -110,19 +110,33 @@ function! sy#stop(bufnr) abort
   call sy#sign#remove_all_signs(a:bufnr)
 endfunction
 
-" Function: #toggle {{{1
-function! sy#toggle() abort
+" Function: #enable {{{1
+function! sy#enable() abort
   if !exists('b:sy')
     call sy#start()
     return
   endif
 
-  if b:sy.active
+  if !b:sy.active
+    let b:sy.active = 1
+    call sy#start()
+  endif
+endfunction
+
+" Function: #disable {{{1
+function! sy#disable() abort
+  if exists('b:sy') && b:sy.active
     call sy#stop(b:sy.buffer)
     let b:sy.active = 0
     let b:sy.stats = [-1, -1, -1]
+  endif
+endfunction
+
+" Function: #toggle {{{1
+function! sy#toggle() abort
+  if !exists('b:sy') || !b:sy.active
+    call sy#enable()
   else
-    let b:sy.active = 1
-    call sy#start()
+    call sy#disable()
   endif
 endfunction

--- a/doc/signify.txt
+++ b/doc/signify.txt
@@ -310,6 +310,20 @@ Default: [3, 8]
 
 ==============================================================================
 COMMAND                                                       *signify-commands*
+                                                        *signify-:SignifyEnable*
+>
+    :SignifyEnable
+<
+Enable the plugin for the current buffer only.
+
+------------------------------------------------------------------------------
+                                                       *signify-:SignifyDisable*
+>
+    :SignifyDisable
+<
+Disable the plugin for the current buffer only.
+
+------------------------------------------------------------------------------
                                                         *signify-:SignifyToggle*
 >
     :SignifyToggle

--- a/plugin/signify.vim
+++ b/plugin/signify.vim
@@ -43,6 +43,8 @@ command! -nargs=0 -bar       SignifyDebugDiff       call sy#debug#verbose_diff_c
 command! -nargs=0 -bar       SignifyDebugUnknown    call sy#repo#debug_detection()
 command! -nargs=0 -bar -bang SignifyFold            call sy#fold#dispatch(<bang>1)
 command! -nargs=0 -bar       SignifyRefresh         call sy#util#refresh_windows()
+command! -nargs=0 -bar       SignifyEnable          call sy#enable()
+command! -nargs=0 -bar       SignifyDisable         call sy#disable()
 command! -nargs=0 -bar       SignifyToggle          call sy#toggle()
 command! -nargs=0 -bar       SignifyToggleHighlight call sy#highlight#line_toggle()
 


### PR DESCRIPTION
These commands allow for a more public interface to disable and enable Signify without having to reach into signify's internals to determine its current state.