### PR TITLE
[RFC] New option: g:signify_sign_show_text

### DIFF
--- a/autoload/sy/highlight.vim
+++ b/autoload/sy/highlight.vim
@@ -3,10 +3,17 @@
 scriptencoding utf-8
 
 " Init: values {{{1
-let s:sign_add               = get(g:, 'signify_sign_add',               '+')
-let s:sign_delete_first_line = get(g:, 'signify_sign_delete_first_line', '‾')
-let s:sign_change            = get(g:, 'signify_sign_change',            '!')
-let s:sign_changedelete      = get(g:, 'signify_sign_changedelete',      s:sign_change)
+if get(g:, 'signify_sign_show_text', 1)
+  let s:sign_add               = get(g:, 'signify_sign_add',               '+')
+  let s:sign_delete_first_line = get(g:, 'signify_sign_delete_first_line', '‾')
+  let s:sign_change            = get(g:, 'signify_sign_change',            '!')
+  let s:sign_changedelete      = get(g:, 'signify_sign_changedelete',      s:sign_change)
+else
+  let s:sign_add               = ' '
+  let s:sign_delete_first_line = ' '
+  let s:sign_change            = ' '
+  let s:sign_changedelete      = ' '
+endif
 let s:sign_show_count        = get(g:, 'signify_sign_show_count',        1)
 
 " Function: #setup {{{1

--- a/autoload/sy/sign.vim
+++ b/autoload/sy/sign.vim
@@ -3,8 +3,13 @@
 scriptencoding utf-8
 
 " Init: values {{{1
-let s:sign_show_count  = get(g:, 'signify_sign_show_count', 1)
-let s:sign_delete      = get(g:, 'signify_sign_delete', '_')
+if get(g:, 'signify_sign_show_text', 1)
+  let s:sign_delete      = get(g:, 'signify_sign_delete', '_')
+  let s:sign_show_count  = get(g:, 'signify_sign_show_count', 1)
+else
+  let s:sign_delete     = ' '
+  let s:sign_show_count = 0
+endif
 let s:delete_highlight = ['', 'SignifyLineDelete']
 
 " Function: #get_next_id {{{1

--- a/doc/signify.txt
+++ b/doc/signify.txt
@@ -105,6 +105,7 @@ All available options:~
     |g:signify_sign_change|
     |g:signify_sign_changedelete|
     |g:signify_sign_show_count|
+    |g:signify_sign_show_text|
     |g:signify_cursorhold_normal|
     |g:signify_cursorhold_insert|
     |g:signify_difftool|
@@ -278,6 +279,20 @@ NOTE: You can use up to 2 characters for the signs with two exceptions that
 Add the number of deleted lines to |g:signify_sign_delete| (up to 99) and
 |g:signify_sign_changedelete| (up to 9). Otherwise only the normal signs will
 be shown.
+
+------------------------------------------------------------------------------
+                                                      *g:signify_sign_show_text*
+>
+    let g:signify_sign_show_text = 1
+<
+Don't show any text in the sign column. (Actually it will show a non-breaking
+space.)
+
+This is useful if you only want to see colors instead. If your colorscheme
+doesn't do it for you, you can set the background color of a particular sign
+yourself: |signify-colors|.
+
+If you want no sign column at all and use Vim 7.4.2201+, use |'signcolumn'|.
 
 ------------------------------------------------------------------------------
                                                    *g:signify_cursorhold_normal*


### PR DESCRIPTION
This makes all Signify signs use a non-breaking space as text. This is
convenient if only the background colors of the signs are important.

References #188.