### PR TITLE
[RFC] Vim: use close_cb to trigger exit_cb

### DIFF
--- a/doc/signify.txt
+++ b/doc/signify.txt
@@ -567,7 +567,7 @@ The plugin is slow!~
 Line highlighting without showing signs?~
 
 The line highlighting relies on signs being placed. The sign column is being
-shown automatically when there are placed signs.
+shown automatically if there are placed signs.
 
 With a recent Vim, you can change that behaviour using 'signcolumn'.
 


### PR DESCRIPTION
Before Vim 8.0.50, an exited job was only detected with a potentially huge
delay.

Thus, for versions smaller than 8.0.50, we add a close_cb callback that runs
job_status() which in return runs the exit_cb callback immeditely if the job was
found to be dead.

Vim patch: https://github.com/vim/vim/commit/01688ad545ff0809ddad5c8fa6b149dc5d67312b

References: #216.