### PR TITLE
[RFC] New option: g:signify_realtime

### DIFF
--- a/doc/signify.txt
+++ b/doc/signify.txt
@@ -47,7 +47,7 @@ Supported VCS:~
     accurev
     perforce
     tfs
-
+<
 ==============================================================================
 MODUS OPERANDI                                          *signify-modus-operandi*
 
@@ -117,9 +117,13 @@ OPTIONS                                                        *signify-options*
 Put these variables into your vimrc. The provided examples also indicate the
 default values, as long as no "Default:" section is given.
 
-All available options:~
+Most important options:~
 
     |g:signify_vcs_list|
+    |g:signify_realtime|
+
+Other options:~
+
     |g:signify_vcs_cmds|
     |g:signify_disable_by_default|
     |g:signify_skip_filetype|
@@ -176,6 +180,32 @@ inactive.)
 NOTE: Some VCS rely on a an external diff tool to work properly (svn, darcs,
 bzr, fossil), thus you have to make sure that Vim can find a valid diff tool.
 So either the one you set through |g:signify_difftool| or "diff" by default.
+
+------------------------------------------------------------------------------
+                                                            *g:signify_realtime*  >
+    let g:signify_realtime = 0
+<
+By default, Sy only updates signs on:
+
+    |BufRead|       (opening a buffer)
+    |BufWritePost|  (saving a buffer)
+
+If that seems too conservative to you and you want more aggressive sign
+updates, enable this option.
+
+This will update signs on:
+
+    |BufEnter|      (opening or switching to another buffer)
+    |WinEnter|      (opening or switching to another window)
+    |BufWritePost|  (saving a buffer)
+    |CursorHold|    (cursor in normal mode wasn't moved for 'updatetime')
+    |CursorHoldI|   (cursor in insert mode wasn't moved for 'updatetime')
+    |FocusGained|   (when the OS window containing Vim got focus)
+
+NOTE: Running Sy on all these events would block too often for older Vim
+versions, thus this option requires Vim 7.4.1967+, which is the minimum
+version Sy needs for asynchronous execution. Older Vim versions silently
+ignore this option.
 
 ------------------------------------------------------------------------------
                                                             *g:signify_vcs_cmds*  >

--- a/plugin/signify.vim
+++ b/plugin/signify.vim
@@ -16,23 +16,28 @@ let g:signify_locked = 0
 augroup signify
   autocmd!
 
-  autocmd BufRead,BufWritePost * call sy#start()
-
   autocmd QuickFixCmdPre  *vimgrep* let g:signify_locked = 1
   autocmd QuickFixCmdPost *vimgrep* let g:signify_locked = 0
 
-  if get(g:, 'signify_update_on_bufenter')
-    autocmd BufEnter * nested call s:save()
-  endif
-  if get(g:, 'signify_cursorhold_normal')
-    autocmd CursorHold * nested call s:save()
-  endif
-  if get(g:, 'signify_cursorhold_insert')
-    autocmd CursorHoldI * nested call s:save()
-  endif
+  if get(g:, 'signify_realtime') && has('patch-7.4.1967')
+    autocmd BufEnter,BufWritePost,WinEnter * call sy#start()
+    autocmd CursorHold,CursorHoldI         * nested call s:save()
+    autocmd FocusGained                    * SignifyRefresh
+  else
+    autocmd BufRead,BufWritePost * call sy#start()
 
-  if get(g:, 'signify_update_on_focusgained') && !has('gui_win32')
-    autocmd FocusGained * SignifyRefresh
+    if get(g:, 'signify_update_on_bufenter')
+      autocmd BufEnter * nested call s:save()
+    endif
+    if get(g:, 'signify_cursorhold_normal')
+      autocmd CursorHold * nested call s:save()
+    endif
+    if get(g:, 'signify_cursorhold_insert')
+      autocmd CursorHoldI * nested call s:save()
+    endif
+    if get(g:, 'signify_update_on_focusgained') && !has('gui_win32')
+      autocmd FocusGained * SignifyRefresh
+    endif
   endif
 augroup END
 


### PR DESCRIPTION
By default Sy only updates signs when opening or writing a buffer that is backed
by a file on disk.

If that's too conservative to you, enable this option. It makes Sy update signs
on almost every occasion.