### PR TITLE
[RFC] Handle nested repos of different VCS

### DIFF
--- a/autoload/sy.vim
+++ b/autoload/sy.vim
@@ -47,7 +47,7 @@ function! sy#start() abort
       return
     endif
     let b:sy.active = 1
-    call sy#repo#detect(1)
+    call sy#repo#detect()
   elseif has('vim_starting')
     call sy#verbose("Don't run Sy more than once during startup.")
     return
@@ -58,7 +58,7 @@ function! sy#start() abort
     if get(b:sy, 'retry')
       let b:sy.retry = 0
       call sy#verbose('Redetecting VCS.')
-      call sy#repo#detect(1)
+      call sy#repo#detect()
     else
       if get(b:sy, 'detecting')
         call sy#verbose('Detection is already in progress.')
@@ -75,20 +75,18 @@ function! sy#start() abort
         call sy#verbose('Update is already in progress.', vcs)
       else
         call sy#verbose('Updating signs.', vcs)
-        call sy#repo#get_diff_start(vcs, 0)
+        call sy#repo#get_diff_start(vcs)
       endif
     endfor
   endif
 endfunction
 
 " Function: #set_signs {{{1
-function! sy#set_signs(sy, vcs, diff, do_register) abort
+function! sy#set_signs(sy, vcs, diff) abort
   call sy#verbose('set_signs()', a:vcs)
 
-  if a:do_register
-    if a:sy.stats == [-1, -1, -1]
-      let a:sy.stats = [0, 0, 0]
-    endif
+  if a:sy.stats == [-1, -1, -1]
+    let a:sy.stats = [0, 0, 0]
   endif
 
   if empty(a:diff)

--- a/autoload/sy.vim
+++ b/autoload/sy.vim
@@ -3,8 +3,6 @@
 scriptencoding utf-8
 
 " Init: values {{{1
-let g:sy_cache = {}
-
 let s:has_doau_modeline = v:version > 703 || v:version == 703 && has('patch442')
 
 " Function: #start {{{1
@@ -91,10 +89,6 @@ function! sy#set_signs(sy, vcs, diff, do_register) abort
     if a:sy.stats == [-1, -1, -1]
       let a:sy.stats = [0, 0, 0]
     endif
-    " let dir = fnamemodify(a:sy.path, ':h')
-    " if !has_key(g:sy_cache, dir)
-    "   let g:sy_cache[dir] = a:sy.vcs
-    " endif
   endif
 
   if empty(a:diff)

--- a/autoload/sy/debug.vim
+++ b/autoload/sy/debug.vim
@@ -22,7 +22,7 @@ function! sy#debug#list_active_buffers() abort
               \ sy.stats[1],
               \ sy.stats[2])
       else
-        echo printf("%10s  =  %s\n", k, sy[k])
+        echo printf("%10s  =  %s\n", k, string(sy[k]))
       endif
     endfor
 

--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -4,17 +4,6 @@ scriptencoding utf-8
 
 " Function: #detect {{{1
 function! sy#repo#detect(do_register) abort
-  " let vcs_list = s:vcs_list
-  " " Simple cache. If there is a registered VCS-controlled file in this
-  " " directory already, assume that this file is probably controlled by
-  " " the same VCS. Thus we shuffle that VCS to the top of our copy of
-  " " s:vcs_list, so we don't affect the preference order of s:vcs_list.
-  " if has_key(g:sy_cache, b:sy_info.dir)
-  "   let vcs_list = [g:sy_cache[b:sy_info.dir]] +
-  "         \ filter(copy(s:vcs_list), 'v:val != "'.
-  "         \        g:sy_cache[b:sy_info.dir] .'"')
-  " endif
-
   for vcs in s:vcs_list
     let b:sy.detecting += 1
     call sy#repo#get_diff_start(vcs, a:do_register)

--- a/autoload/sy/sign.vim
+++ b/autoload/sy/sign.vim
@@ -195,9 +195,13 @@ function! sy#sign#process_diff(sy, vcs, diff) abort
     call feedkeys("\<c-l>")
   endif
 
-  call sy#verbose('Signs updated. Disable other VCS.', a:vcs)
-  let a:sy.vcs = [a:vcs]
-  let a:sy.updated_by = a:vcs
+  call sy#verbose('Signs updated.', a:vcs)
+  if len(a:sy.vcs) > 1
+    call sy#verbose('Disable all other VCS.', a:vcs)
+    let a:sy.vcs = [a:vcs]
+    let a:sy.updated_by = a:vcs
+  endif
+
   let a:sy.stats = [added, modified, deleted]
 endfunction
 

--- a/autoload/sy/sign.vim
+++ b/autoload/sy/sign.vim
@@ -50,7 +50,7 @@ endfunction
 
 
 " Function: #process_diff {{{1
-function! sy#sign#process_diff(sy, diff) abort
+function! sy#sign#process_diff(sy, vcs, diff) abort
   let a:sy.signtable             = {}
   let a:sy.hunks                 = []
   let [added, modified, deleted] = [0, 0, 0]
@@ -195,6 +195,9 @@ function! sy#sign#process_diff(sy, diff) abort
     call feedkeys("\<c-l>")
   endif
 
+  call sy#verbose('Signs updated. Disable other VCS.', a:vcs)
+  let a:sy.vcs = [a:vcs]
+  let a:sy.updated_by = a:vcs
   let a:sy.stats = [added, modified, deleted]
 endfunction
 


### PR DESCRIPTION
Let's take the example from https://github.com/mhinz/vim-signify/issues/235.

I assume that `f` has no changes initially. Do all steps in the given order and use `:messages` after `:w` to get the full output.

<details>
<summary>nvim -V1 f</summary>

```
[sy] Register new file.
[sy:git] get_diff_start()
[sy:git] CMD: ['sh', '-c', 'git diff --no-color --no-ext-diff -U0 -- ''f'''] | CWD: /private/tmp/x/y
[sy:svn] get_diff_start()
[sy:svn] CMD: ['sh', '-c', 'svn diff --diff-cmd ''diff'' -x -U0 -- ''/private/tmp/x/y/f'''] | CWD: /private/tmp/x/y
[sy:hg] get_diff_start()
[sy:hg] CMD: ['sh', '-c', 'hg diff --config extensions.color=! --config defaults.diff= --nodates -U0 -- ''/private/tmp/x/y/f'''] | CWD: /private/tmp/x/y
[sy:git] job_exit()
[sy:git] get_diff_git()
[sy:git] get_diff_end()
[sy:git] set_signs()
[sy:git] No changes found.
[sy:svn] job_exit()
[sy:svn] get_diff_svn()
[sy:svn] get_diff_end()
[sy:svn] No valid diff found. Disabling this VCS.
[sy:hg] job_exit()
[sy:hg] get_diff_hg()
[sy:hg] get_diff_end()
[sy:hg] set_signs()
[sy:hg] No changes found.
```
</details>

You can see that Sy tries git, hg and svn. It finds no valid diff for svn though and disables it. `:SignifyList` now shows `vcs  =  ['git', 'hg']`.

<details>
<summary>:w</summary>

```
[sy:git] Updating signs.
[sy:git] get_diff_start()
[sy:git] CMD: ['sh', '-c', 'git diff --no-color --no-ext-diff -U0 -- ''f'''] | CWD: /private/tmp/x/y
[sy:hg] Updating signs.
[sy:hg] get_diff_start()
[sy:hg] CMD: ['sh', '-c', 'hg diff --config extensions.color=! --config defaults.diff= --nodates -U0 -- ''/private/tmp/x/y/f'''] | CWD: /private/tmp/x/y
[sy:git] job_exit()
[sy:git] get_diff_git()
[sy:git] get_diff_end()
[sy:git] set_signs()
[sy:git] No changes found.
[sy:hg] job_exit()
[sy:hg] get_diff_hg()
[sy:hg] get_diff_end()
[sy:hg] set_signs()
[sy:hg] No changes found.
```
</details>

We can see that Sy didn't bother to check for svn indeed. Now, add any new line.

<details>
<summary>:w</summary>

```
[sy:git] Updating signs.
[sy:git] get_diff_start()
[sy:git] CMD: ['sh', '-c', 'git diff --no-color --no-ext-diff -U0 -- ''f'''] | CWD: /private/tmp/x/y
[sy:hg] Updating signs.
[sy:hg] get_diff_start()
[sy:hg] CMD: ['sh', '-c', 'hg diff --config extensions.color=! --config defaults.diff= --nodates -U0 -- ''/private/tmp/x/y/f'''] | CWD: /private/tmp/x/y
[sy:git] job_exit()
[sy:git] get_diff_git()
[sy:git] get_diff_end()
[sy:git] set_signs()
[sy:git] Signs updated.
[sy:git] Disable all other VCS.
[sy:hg] job_exit()
[sy:hg] Signs already got updated by git.
```
</details>

Note how the hg check detects that the signs already got updated by git in this update step. All VCS but git get disabled to reduce overhead. (Verify that via `:SignifyList`). From now, only git will be checked on each sign update.