### PR TITLE
MacVim: Do not remap ^L

### DIFF
--- a/autoload/sy/sign.vim
+++ b/autoload/sy/sign.vim
@@ -191,7 +191,7 @@ function! sy#sign#process_diff(sy, vcs, diff) abort
   if has('gui_macvim') && has('gui_running') && mode() == 'n'
     " MacVim needs an extra kick in the butt, when setting signs from the
     " exit handler. :redraw would trigger a "hanging cursor" issue.
-    call feedkeys("\<c-l>")
+    call feedkeys("\<c-l>", 'n')
   endif
 
   call sy#verbose('Signs updated.', a:vcs)


### PR DESCRIPTION
The commit message explains the issue, but here's a concrete example: given a mapping `nnoremap <C-l> <C-w>l`, the `feedkeys("\<C-l>")` call will result in `<C-w>l`.