### PR TITLE
Rewrite vim-gitgutter suggestion in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ removed lines in a file that is managed by a version control system (VCS)._
 
 ---
 
-_If git is the only version control system you use, I suggest having a look at
-[vim-gitgutter](https://github.com/airblade/vim-gitgutter)._
+_Similar plugin for git: [vim-gitgutter](https://github.com/airblade/vim-gitgutter)_
 
 ## Installation
 


### PR DESCRIPTION
I think signify shouldn't underrate itself. In my honest opinion signify is better than gitgutter. It's just a better product and users should consider using this plugin even if git is the only version control system they use.

When I first saw that statement I thought even the author of this plugin suggests using gitgutter, then gitgutter must be better than signify. I believe newcomers think like that too.

Long story short, I propose to remove that sentence altogether. 