### PR TITLE
allow `p4 diff` command to actually work on Windows (prevent missing env command error)

### DIFF
--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -452,7 +452,7 @@ let s:default_vcs_cmds = {
       \ 'cvs':      'cvs diff -U0 -- %f',
       \ 'rcs':      'rcsdiff -U0 %f 2>%n',
       \ 'accurev':  'accurev diff %f -- -U0',
-      \ 'perforce': 'p4 info '. sy#util#shell_redirect('%n') .' && env P4DIFF=%d p4 diff -dU0 %f',
+      \ 'perforce': 'p4 info '. sy#util#shell_redirect('%n') .' && p4 diff -du0 %f',
       \ 'tfs':      'tf diff -version:W -noprompt -format:Unified %f'
       \ }
 


### PR DESCRIPTION
I fixed this for Windows. I could not test on other platforms. Please let me know if changes are needed to make this work everywhere. Thanks!