### PR TITLE
Fix invocation of p4 diff

### DIFF
--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -452,7 +452,7 @@ let s:default_vcs_cmds = {
       \ 'cvs':      'cvs diff -U0 -- %f',
       \ 'rcs':      'rcsdiff -U0 %f 2>%n',
       \ 'accurev':  'accurev diff %f -- -U0',
-      \ 'perforce': 'p4 info '. sy#util#shell_redirect('%n') . (has('win32') ? '' : ' env P4DIFF= P4COLORS=') .' p4 diff -du0 %f',
+      \ 'perforce': 'p4 info '. sy#util#shell_redirect('%n') . (has('win32') ? ' &&' : ' && env P4DIFF= P4COLORS=') .' p4 diff -du0 %f',
       \ 'tfs':      'tf diff -version:W -noprompt -format:Unified %f'
       \ }
 


### PR DESCRIPTION
Commit cc2b17d462c9460c2f5f4a0d71a3edf6e6a71987 removed the '&&' used to check whether the p4 info command succeeded. This caused incorrect invocation of the p4 diff command.
Add back the check for p4 info command success.

Prior to this commit the command invoked was:
p4 info >/dev/null 2>&1 env P4DIFF= P4COLORS= p4 diff -du0

This commit makes the invocation as:
p4 info >/dev/null 2>&1 && env P4DIFF= P4COLORS= p4 diff -du0