### PR TITLE
Add option to split diff in current tab instead of new tab.

### DIFF
--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -252,7 +252,8 @@ function! sy#repo#diffmode() abort
   let cmd = s:expand_cmd(vcs, g:signify_vcs_cmds_diffmode)
   call sy#verbose('SignifyDiff: '. cmd, vcs)
   let ft = &filetype
-  tabedit %
+  let newtab = exists('b:signify_newtab') ? b:signify_newtab : g:signify_newtab
+  if newtab | tabedit % | endif
   diffthis
   let [cwd, chdir] = sy#util#chdir()
   try

--- a/plugin/signify.vim
+++ b/plugin/signify.vim
@@ -10,6 +10,7 @@ endif
 let g:loaded_signify = 1
 let g:signify_locked = 0
 let s:has_doau_modeline = v:version > 703 || v:version == 703 && has('patch442')
+let g:signify_newtab = get(g:, 'signify_newtab', 1)
 
 " Init: autocmds {{{1
 augroup signify


### PR DESCRIPTION
I added the option `signify_newtab` which defaults to 1 for the current behavior of splitting the diff in a new tab.

If `g:signify_newtab` or `b:signify_newtab` is set to 0, when `:SignifyDiff` is called, the split is made in the current tab.