### PR TITLE
Hg: change default invocation

### DIFF
--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -443,7 +443,7 @@ endif
 
 let s:default_vcs_cmds = {
       \ 'git':      'git diff --no-color --no-ext-diff -U0 -- %f',
-      \ 'hg':       'hg diff --config extensions.color=! --config defaults.diff= --nodates -U0 -- %f',
+      \ 'hg':       'hg diff --color=never --config aliases.diff= --nodates -U0 -- %f',
       \ 'svn':      'svn diff --diff-cmd %d -x -U0 -- %f',
       \ 'bzr':      'bzr diff --using %d --diff-options=-U0 -- %f',
       \ 'darcs':    'darcs diff --no-pause-for-gui --no-unified --diff-opts=-U0 -- %f',


### PR DESCRIPTION
Mercurial used to enable colors via an extension. Nowadays that is not true
anymore and `extensions.color=!` is rendered useless. Use the omnipresent
`--color=never` instead.

`defaults` is deprecated in favor of `aliases`. We use `aliases.diff=` to force
the use of the standard diff behaviour of `hg diff` which is the same as from
GNU diff. Otherwise an external diff tool could produce output that signify does
not understand.

References: https://github.com/mhinz/vim-signify/issues/272