### PR TITLE
SignifyDiff: convert encoding based on fileencoding

### DIFF
--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -252,6 +252,7 @@ function! sy#repo#diffmode(do_tab) abort
   let cmd = s:expand_cmd(vcs, g:signify_vcs_cmds_diffmode)
   call sy#verbose('SignifyDiff: '. cmd, vcs)
   let ft = &filetype
+  let fenc = &fenc
   if a:do_tab
     tabedit %
   endif
@@ -260,7 +261,11 @@ function! sy#repo#diffmode(do_tab) abort
   try
     execute chdir fnameescape(b:sy.info.dir)
     leftabove vnew
-    silent put =system(cmd)
+    if has('iconv')
+      silent put =iconv(system(cmd), fenc, &enc)
+    else
+      silent put =system(cmd)
+    endif
   finally
     execute chdir fnameescape(cwd)
   endtry


### PR DESCRIPTION
Thanks for developing a nice plugin!

Sometimes I have to edit files of different `&fileencoding` from `&enc`.
For such files, the output of `SignifyDiff` are not correctly encoded.

This pull request is to fix the problem by converting the output of `system()` from `&fileencoding` to `&enc`.
I confirmed this works fine on macOS mojave and Windows 10 using git and svn.