### PR TITLE
Fossil: fix detection of deleted lines

### DIFF
--- a/autoload/sy/sign.vim
+++ b/autoload/sy/sign.vim
@@ -93,7 +93,7 @@ function! sy#sign#process_diff(sy, vcs, diff) abort
     elseif (old_count >= 1) && (new_count == 0)
       if s:external_sign_present(a:sy, new_line) | continue | endif
       let deleted += old_count
-      if new_line == 0
+      if old_line == 1
         call add(ids, s:add_sign(a:sy, 1, 'SignifyRemoveFirstLine'))
       elseif s:sign_show_count
         let text = s:sign_delete . (old_count <= 99 ? old_count : '>')


### PR DESCRIPTION
Assuming line 28 was deleted, the block header for a unified diff looks like:

    +28,1 -27,0

This is true for usual suspects like `diff -U0` and `git diff -U0`, but
unfortunately not for Fossil. It would report this instead:

    +28,1 -0,0

This lead our code to believe that line 1 instead of line 28 was deleted. And
maybe it's right about that. There does not seem to be a standard for patch/diff
output, but according to my knowledge Fossil is the only VCS doing that.

Anyway, this commit's change should make the detection of a deleted first line
work for every VCS again.

Fixes https://github.com/mhinz/vim-signify/issues/282