### PR TITLE
Add &shellquote to job cmd on Windows

### DIFF
--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -299,7 +299,7 @@ function! s:initialize_job(vcs) abort
     if has('nvim')
       let cmd = &shell =~ 'cmd' ? vcs_cmd : ['sh', '-c', vcs_cmd]
     else
-      let cmd = join([&shell, &shellcmdflag, vcs_cmd])
+      let cmd = join([&shell, &shellcmdflag, &shellquote, vcs_cmd, &shellquote])
     endif
   else
     let cmd = ['sh', '-c', vcs_cmd]


### PR DESCRIPTION
Currently `&shellquote` is missing for the job command of Vim on Windows.
Therefore I can't use sh.exe as `&shell`.

`:help shellquote` says

> This is an empty string by default.  Only known to be useful for
> third-party shells on MS-DOS-like systems, such as the MKS Korn Shell
> or bash, where it should be "\"".  The default is adjusted according
> the value of 'shell', to reduce the need to set this option by the
> user.  See |dos-shell|.

This PR adds `&shellquote` to the job command. I tested with svn on Windows 10.
With `&shellquote`, sh.exe works well.
When using cmd.exe, `&shellquote` is empty as default and this plugin works as before.