### PR TITLE
Use one of &shellxquote and &shellquote

### DIFF
--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -299,7 +299,13 @@ function! s:initialize_job(vcs) abort
     if has('nvim')
       let cmd = &shell =~ 'cmd' ? vcs_cmd : ['sh', '-c', vcs_cmd]
     else
-      let cmd = join([&shell, &shellcmdflag, &shellquote, vcs_cmd, &shellquote])
+      if &shell =~ 'cmd'
+        let cmd = vcs_cmd
+      elseif empty(&shellxquote)
+        let cmd = join([&shell, &shellcmdflag, &shellquote, vcs_cmd, &shellquote])
+      else
+        let cmd = join([&shell, &shellcmdflag, &shellxquote, vcs_cmd, &shellxquote])
+      endif
     endif
   else
     let cmd = ['sh', '-c', vcs_cmd]


### PR DESCRIPTION
This PR is related to https://github.com/mhinz/vim-signify/pull/288.

When `&shell==sh.exe` on Win32, default value of `&shellquote` is empty and `&shellxquote` is double quotation (`:help dos-shell`). In the case, we should use `&shellxquote`, not `&shellquote`. Usually, only one of `&shellquote` and `&shellxquote` is non-empty.

`:help shellquote` says

> Quoting character(s), put around the command passed to the shell, for
> the "!" and ":!" commands.  The redirection is kept outside of the
> quoting.  See 'shellxquote' to include the redirection.  It's
> probably not useful to set both options.

`:help shellxquote` says

> Quoting character(s), put around the command passed to the shell, for
> the "!" and ":!" commands.  Includes the redirection.  See
> 'shellquote' to exclude the redirection.  It's probably not useful
> to set both options.


When `&shell==cmd.exe` (as default), `&shellquote==""` and `&shellxquote=="("` are the default values. In the case we should not use `&shellxquote`.

I tested the following three cases with SVN on Windows 10.

* `&shell==cmd.exe`, `&shellquote` is empty and `&shellxquote=="("` (all values are defaults)
* `&shell==sh.exe`, `&shellquote` is empty and `&shellxquote` is double quotation (defaults for sh.exe)
* `&shell==sh.exe`, `&shellquote` is double quotation and `&shellxquote` empty

Sorry for the previous careless PR.