### PR TITLE
Fix CVS recognition when diff is valid but empty

### DIFF
--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -191,6 +191,8 @@ function! sy#repo#get_diff_cvs(sy, exitval, diff) abort
         break
       endif
     endfor
+  elseif a:exitval == 0 && len(a:diff) == 0
+    let found_diff = 1
   endif
   call s:get_diff_end(a:sy, found_diff, 'cvs', diff)
 endfunction


### PR DESCRIPTION
CVS diff return code is 1 when the file differs from HEAD revision or
when there is an error (e.g. file is not under revision control),
while it is 0 (with an empty output) when the file is up-to-date.
The latter case was not handled, causing vim-signify to not recognize a
file under CVS when it did not have any change.