### PR TITLE
SignifyDiffPreview: convert encoding of hunks

### DIFF
--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -116,6 +116,10 @@ function! s:handle_diff(options, exitval) abort
     let sy.detecting -= 1
   endif
 
+  if has('iconv')
+    call map(a:options.stdoutbuf, 'iconv(v:val, &fenc, &enc)')
+  endif
+
   let [found_diff, diff] = s:check_diff_{a:options.vcs}(a:exitval, a:options.stdoutbuf)
   if found_diff
     if index(sy.vcs, a:options.vcs) == -1

--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -116,7 +116,7 @@ function! s:handle_diff(options, exitval) abort
     let sy.detecting -= 1
   endif
 
-  if has('iconv')
+  if (&fenc != &enc) && has('iconv')
     call map(a:options.stdoutbuf, 'iconv(v:val, &fenc, &enc)')
   endif
 
@@ -257,7 +257,7 @@ function! sy#repo#diffmode(do_tab) abort
   try
     execute chdir fnameescape(b:sy.info.dir)
     leftabove vnew
-    if has('iconv')
+    if (fenc != &enc) && has('iconv')
       silent put =iconv(system(cmd), fenc, &enc)
     else
       silent put =system(cmd)


### PR DESCRIPTION
This PR fixes the encoding problem using `&fenc` and `&enc` as same as https://github.com/mhinz/vim-signify/pull/278.

#300 