### PR TITLE
:SignifyRevert

### DIFF
--- a/plugin/signify.vim
+++ b/plugin/signify.vim
@@ -68,6 +68,7 @@ command! -nargs=0 -bar -bang SignifyFold            call sy#fold#dispatch(<bang>
 command! -nargs=0 -bar -bang SignifyDiff            call sy#repo#diffmode(<bang>1)
 command! -nargs=0 -bar       SignifyDiffPreview     call sy#repo#preview_hunk()
 command! -nargs=0 -bar       SignifyRefresh         call sy#util#refresh_windows()
+command! -nargs=0 -bar       SignifyRevert          call sy#repo#revert_hunk()
 command! -nargs=0 -bar       SignifyEnable          call sy#enable()
 command! -nargs=0 -bar       SignifyDisable         call sy#disable()
 command! -nargs=0 -bar       SignifyToggle          call sy#toggle()


### PR DESCRIPTION
Add :SignifyRevert to revert a hunk.

This works by applying the current hunk into the current buffer
backwards.

If the buffer is not saved to disk this can cause conflicts in which
case the revert will abort part-way though. This could be fixed by
diffing against the buffer (see
#306).

Fixes half of https://github.com/mhinz/vim-signify/issues/119