### PR TITLE
Saveless Updates

### DIFF
--- a/autoload/sy.vim
+++ b/autoload/sy.vim
@@ -72,7 +72,7 @@ function! sy#start() abort
         call sy#verbose('Update is already in progress.', vcs)
       else
         call sy#verbose('Updating signs.', vcs)
-        call sy#repo#get_diff(vcs, function('sy#sign#set_signs'))
+        call sy#repo#get_diff(vcs, g:signify_live, function('sy#sign#set_signs'))
       endif
     endfor
   endif

--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -206,7 +206,17 @@ function! sy#repo#debug_detection()
   endfor
 endfunction
 
-" #diffmode {{{1
+function! s:system_in_dir(cmd) abort
+  let [cwd, chdir] = sy#util#chdir()
+  try
+    execute chdir fnameescape(b:sy.info.dir)
+    return system(a:cmd)
+  finally
+    execute chdir fnameescape(cwd)
+  endtry
+endfunction
+
+" Function: #diffmode {{{1
 function! sy#repo#diffmode(do_tab) abort
   execute sy#util#return_if_no_changes()
 
@@ -224,18 +234,14 @@ function! sy#repo#diffmode(do_tab) abort
     tabedit %
   endif
   diffthis
-  let [cwd, chdir] = sy#util#chdir()
-  try
-    execute chdir fnameescape(b:sy.info.dir)
-    leftabove vnew
-    if (fenc != &enc) && has('iconv')
-      silent put =iconv(system(cmd), fenc, &enc)
-    else
-      silent put =system(cmd)
-    endif
-  finally
-    execute chdir fnameescape(cwd)
-  endtry
+
+  leftabove vnew
+  if (fenc != &enc) && has('iconv')
+    silent put =iconv(s:system_in_dir(cmd), fenc, &enc)
+  else
+    silent put =s:system_in_dir(cmd)
+  endif
+
   silent 1delete
   set buftype=nofile bufhidden=wipe nomodified
   let &filetype = ft
@@ -404,16 +410,13 @@ endfunction
 
 " s:run {{{1
 function! s:run(vcs)
-  let [cwd, chdir] = sy#util#chdir()
   try
-    execute chdir fnameescape(b:sy.info.dir)
-    let ret = system(s:expand_cmd(a:vcs, g:signify_vcs_cmds))
+    let ret = s:system_in_dir(s:expand_cmd(a:vcs, g:signify_vcs_cmds))
   catch
     " This exception message can be seen via :SignifyDebugUnknown.
     " E.g. unquoted VCS programs in vcd_cmds can lead to E484.
     let ret = v:exception .' at '. v:throwpoint
   finally
-    execute chdir fnameescape(cwd)
     return ret
   endtry
 endfunction


### PR DESCRIPTION
This updates signify to diff against the buffer instead of the on-disk file. This for example makes `:SignifyRefresh` work properly.

This will allow us to remove autosave from realtime mode.

Fixes #306, #230 