### PR TITLE
Doc improvements

### DIFF
--- a/doc/signify.txt
+++ b/doc/signify.txt
@@ -56,7 +56,7 @@ When you open a new buffer, Sy registers it as `active` and tries to figure out
 whether the underlying file is controlled by a VCS (version control system) or
 not.
 
-For that, it asynchronously tries all the `diff` subcommands of all the VCS
+For that, it asynchronously tries all the `diff` sub commands of all the VCS
 tools that are supported and executable. It's recommended to set
 |g:signify_vcs_list| to limit the VCS to test for.
 
@@ -71,7 +71,7 @@ Or you set |g:signify_disable_by_default|, which registers all new buffers as
 `inactive`, and enable Sy on demand using |signify-:SignifyToggle|.
 
 By default, Sy is rather conservative and only updates signs when opening a
-new buffer or writing it. If you want more agressive sign updating, have a
+new buffer or writing it. If you want more aggressive sign updating, have a
 look at |g:signify_realtime|.
 
 Use |signify-:SignifyList| to list all buffers managed by Sy and their current
@@ -108,7 +108,7 @@ SIGNS                                                            *signify-signs*
     `99`    than 9, the `_` will be omitted. For numbers larger than 99, `_>`
     `_>`    will be shown instead.
 
-    `!1`    This line was modified and a number of lines below were deleted.
+    `!1`    This line was modified and the lines below were deleted.
     `!>`    It is a combination of `!` and `_`. If the number is larger than 9,
           `!>` will be shown instead.
 
@@ -172,19 +172,19 @@ NOTE: This is the most important option, so read closely.
 
 This option determines what VCS to check for.
 
-This can improve buffer loading time, since by default all supported and
+This can improve buffer loading time since by default all supported and
 installed VCS will be checked for. This only happens once, when signs get set
-the first time. Afterwards, the VCS will either be remembered or registered as
+the first time. Afterward, the VCS will either be remembered or registered as
 inactive when no VCS was found.
 
 If your Vim is recent enough, these checks will happen asynchronously.
 
 NOTE: If you don't set this option, updating signs for a non-VCS file can lead
 to a significant delay since all supported and installed VCS will be tested
-for. (But this also happens only once, afterwards the buffer is registered as
+for. (But this also happens only once, afterward the buffer is registered as
 inactive.)
 
-NOTE: Some VCS rely on a an external diff tool to work properly (svn, darcs,
+NOTE: Some VCS rely on an external diff tool to work properly (svn, darcs,
 bzr, fossil), thus you have to make sure that Vim can find a valid diff tool.
 So either the one you set through |g:signify_difftool| or "diff" by default.
 
@@ -352,8 +352,8 @@ Enable line highlighting in addition to using signs by default.
 The sign to use if a line was added, deleted or changed or a combination of
 these.
 
-You can use unicode characters, but signs must not take up more than two
-cells. Otherwise |E239| is thrown.
+You can use Unicode characters, but signs must not take up more than two
+cells. Otherwise, |E239| is thrown.
 
 If |g:signify_sign_show_count| is set, |g:signify_sign_delete| and
 |g:signify_sign_changedelete| get truncated as needed.
@@ -363,7 +363,7 @@ If |g:signify_sign_show_count| is set, |g:signify_sign_delete| and
     let g:signify_sign_show_count = 1
 <
 Add the number of deleted lines to |g:signify_sign_delete| (up to 99) and
-|g:signify_sign_changedelete| (up to 9). Otherwise only the normal signs will
+|g:signify_sign_changedelete| (up to 9). Otherwise, only the normal signs will
 be shown.
 
 ------------------------------------------------------------------------------
@@ -386,8 +386,8 @@ If you want no sign column at all and use Vim 7.4.2201+, use 'signcolumn'.
     let g:signify_cursorhold_insert = 0
 <
 Additionally trigger sign updates in normal or insert mode after 'updatetime'
-miliseconds without any keypresses. This fires only once between keypresses,
-thus not every 'updatetime' miliseconds.
+milliseconds without any key presses. This fires only once between key presses,
+thus not every 'updatetime' milliseconds.
 
 NOTE: This also saves the buffer to disk!
 
@@ -468,17 +468,17 @@ Also see |g:signify_vcs_cmds_diffmode|.
                                                           *signify-:SignifyFold*  >
     :SignifyFold[!]
 <
-Open the current buffer in a new tabpage and set 'foldexpr' so that only
+Open the current buffer in a new tab page and set 'foldexpr' so that only
 changed lines with their surrounding context are unfolded.
 
 The number of lines per context can be changed via |g:signify_fold_context|.
 
 The |foldtext| will be set so that the left side shows the first line in the
 fold and the right side shows something like "50 [1]" which whereas "50"
-stands for the number of folded lines and the "1" is the foldlevel.
+stands for the number of folded lines and the "1" is the 'foldlevel'.
 
-If [!] is given, Sy will do the same without opening an extra tabpage. Another
-":SignifyFold!" will toggle back to the previous settings.
+If [!] is given, Sy will do the same without opening an extra tab page.
+Another ":SignifyFold!" will toggle back to the previous settings.
 
 See |folds| to learn more about folding.
 
@@ -519,11 +519,11 @@ MAPPINGS                                                      *signify-mappings*
 ------------------------------------------------------------------------------
 Hunk jumping:~
 
-    ]c   Jump to next hunk.
-    [c   Jump to previous hunk.
+    ]c   Jump to the next hunk.
+    [c   Jump to the previous hunk.
 
-    ]C   Jump to last hunk.
-    [C   Jump to first hunk.
+    ]C   Jump to the last hunk.
+    [C   Jump to the first hunk.
 
 These keys only get mapped by default when:
 
@@ -555,7 +555,7 @@ NOTE: Don't be surprised that this also works with "deleted lines".
 COLORS                                                          *signify-colors*
 
 This plugin defines highlighting groups for two different places: for lines
-and signs. Per default these don't really exist but are linked to the standard
+and signs. Per default these don't exist but are linked to the standard
 highlighting groups: |hl-DiffAdd|, |hl-DiffChange|, |hl-DiffDelete|:
 >
     highlight link SignifyLineAdd             DiffAdd
@@ -578,7 +578,7 @@ Assuming you prefer |hl-DiffText| over |hl-DiffChange| for changed lines:
 >
     highlight link SignifyLineChange DiffText
 <
-Personally I use (256 colors terminal):
+Personally, I use (256 colors terminal):
 >
     " highlight lines in Sy and vimdiff etc.)
 
@@ -653,7 +653,7 @@ The plugin is slow!~
     If you use a decentralized VCS like Git, are you working on a slow remote
     file system?
 
-  * Vim its sign handling code is known to be slow. If the delay is very long,
+  * Vim's sign handling code is known to be slow. If the delay is very long,
     chances are the diff is just huge. This often happens after adding (or
     removing) a huge file to the repo.
 
@@ -664,7 +664,7 @@ Line highlighting without showing signs?~
 The line highlighting relies on signs being placed. The sign column is being
 shown automatically if there are placed signs.
 
-With a recent Vim, you can change that behaviour using 'signcolumn'.
+With a recent Vim, you can change that behavior using 'signcolumn'.
 
 ==============================================================================
 EXAMPLE                                                        *signify-example*


### PR DESCRIPTION
I found some misspelled words in the docs. (I checked again using Grammarly that they are actually misspelled)

While I was at it I also made (very small) changes to some formulations and added some links.

Note: I didn't correct all misspelled words I found. Only those that I thought make sense. Some words make more sense without a space in programming context. But some changes I make are probably still debatable (e.g. `tabpage`).

---

I would also consider adding this to the example highlight colors (around line 583):

```vim
highlight link SignifySignAdd             SignifySignAdd
highlight link SignifySignChange          SignifySignChange
highlight link SignifySignDelete          SignifySignDelete
```

The docs could maybe also mention the gui colors in rgb or at least that you need to set them for gui vim separately using something like this:

```vim
highlight DiffAdd gui=bold guibg=none guifb=#87ff5f
```

I can add that to this PR if you want.