### PR TITLE
Do not change directory manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ removed lines in a file that is managed by a version control system (VCS)._
 
 - Supports **git**, **mercurial**, **darcs**, **bazaar**, **subversion**,
   **cvs**, **rcs**, **fossil**, **accurev**, **perforce**, **tfs**, **yadm**.
-- **Asynchronous** execution of VCS tools for Vim 7.4.1967+ and Neovim.
+- **Asynchronous** execution of VCS tools for Vim 8.0.902+ and Neovim.
 - **Preserves signs** from other plugins.
 - Handles **nested repositories** controlled by different VCS.
 - Provides mappings for **navigating hunks** ("blocks of changed lines").


### PR DESCRIPTION
Using the `'cwd'` key for jobs avoids manually changing directories.

Fixes https://github.com/mhinz/vim-signify/issues/312