### PR TITLE
Improve handling of disabled buffers

### DIFF
--- a/autoload/sy.vim
+++ b/autoload/sy.vim
@@ -80,6 +80,22 @@ function! sy#toggle() abort
   call call(empty(getbufvar(bufnr(''), 'sy')) ? 'sy#start' : 'sy#stop', [])
 endfunction
 
+" #start_all {{{1
+function! sy#start_all() abort
+  for bufnr in range(1, bufnr(''))
+    call sy#start({'bufnr': bufnr})
+  endfor
+endfunction
+
+" #stop_all {{{1
+function! sy#stop_all() abort
+  for bufnr in range(1, bufnr(''))
+    if !empty(getbufvar(bufnr, 'sy'))
+      call sy#stop(bufnr)
+    endif
+  endfor
+endfunction
+
 " #buffer_is_active {{{1
 function! sy#buffer_is_active()
   return !empty(getbufvar(bufnr(''), 'sy'))

--- a/autoload/sy.vim
+++ b/autoload/sy.vim
@@ -116,10 +116,6 @@ endfunction
 
 " #set_buflocal_autocmds {{{1
 function! sy#set_buflocal_autocmds(bufnr) abort
-  if get(g:, 'signify_disable_by_default')
-    return
-  endif
-
   augroup signify
     execute printf('autocmd! * <buffer=%d>', a:bufnr)
 

--- a/autoload/sy.vim
+++ b/autoload/sy.vim
@@ -71,8 +71,7 @@ function! sy#stop(...) abort
   let bufnr = bufnr('')
   if empty(getbufvar(a:0 ? a:1 : bufnr, 'sy')) | return | endif
   call sy#sign#remove_all_signs(bufnr)
-  " TODO: Can't unset autocmds in another buffer.
-  autocmd! signify * <buffer>
+  execute printf('autocmd! signify * <buffer=%d>', bufnr)
   call setbufvar(bufnr, 'sy', {})
 endfunction
 
@@ -102,7 +101,7 @@ endfunction
 " #set_autocmds {{{1
 function! sy#set_autocmds() abort
   augroup signify
-    autocmd!
+    autocmd! * <buffer>
 
     autocmd BufEnter     <buffer> call sy#start()
     autocmd WinEnter     <buffer> call sy#start()

--- a/autoload/sy.vim
+++ b/autoload/sy.vim
@@ -35,7 +35,7 @@ function! sy#start(...) abort
           \    'file': sy#util#escape(fnamemodify(path, ':t'))
           \ }}
     call setbufvar(bufnr, 'sy', new_sy)
-    call sy#set_autocmds()
+    call sy#set_buflocal_autocmds(bufnr)
     call sy#repo#detect(bufnr)
   elseif has('vim_starting')
     call sy#verbose("Don't run Sy more than once during startup.")
@@ -114,35 +114,31 @@ function! sy#verbose(msg, ...) abort
   endif
 endfunction
 
-" #set_autocmds {{{1
-function! sy#set_autocmds() abort
+" #set_buflocal_autocmds {{{1
+function! sy#set_buflocal_autocmds(bufnr) abort
+  if get(g:, 'signify_disable_by_default')
+    return
+  endif
+
   augroup signify
-    autocmd! * <buffer>
+    execute printf('autocmd! * <buffer=%d>', a:bufnr)
 
-    autocmd BufEnter     <buffer> call sy#start()
-    autocmd WinEnter     <buffer> call sy#start()
-    autocmd BufWritePost <buffer> call sy#start()
+    execute printf('autocmd BufEnter     <buffer=%d> call sy#start()', a:bufnr)
+    execute printf('autocmd WinEnter     <buffer=%d> call sy#start()', a:bufnr)
+    execute printf('autocmd BufWritePost <buffer=%d> call sy#start()', a:bufnr)
 
-    autocmd CursorHold   <buffer> call sy#start()
-    autocmd CursorHoldI  <buffer> call sy#start()
+    execute printf('autocmd CursorHold   <buffer=%d> call sy#start()', a:bufnr)
+    execute printf('autocmd CursorHoldI  <buffer=%d> call sy#start()', a:bufnr)
 
-    autocmd FocusGained  <buffer> SignifyRefresh
+    execute printf('autocmd FocusGained  <buffer=%d> SignifyRefresh', a:bufnr)
 
-    autocmd QuickFixCmdPre  *vimgrep* let g:signify_locked = 1
-    autocmd QuickFixCmdPost *vimgrep* let g:signify_locked = 0
+    execute printf('autocmd CmdwinEnter <buffer=%d> let g:signify_cmdwin_active = 1', a:bufnr)
+    execute printf('autocmd CmdwinLeave <buffer=%d> let g:signify_cmdwin_active = 0', a:bufnr)
 
-    autocmd CmdwinEnter <buffer> let g:signify_cmdwin_active = 1
-    autocmd CmdwinLeave <buffer> let g:signify_cmdwin_active = 0
-
-    autocmd ShellCmdPost <buffer> call sy#start()
+    execute printf('autocmd ShellCmdPost <buffer=%d> call sy#start()', a:bufnr)
 
     if exists('##VimResume')
-      autocmd VimResume <buffer> call sy#start()
-    endif
-
-    if has('gui_running') && has('win32') && argc()
-      " Fix 'no signs at start' race.
-      autocmd GUIEnter <buffer> redraw
+      execute printf('autocmd VimResume <buffer=%d> call sy#start()', a:bufnr)
     endif
   augroup END
 

--- a/autoload/sy.vim
+++ b/autoload/sy.vim
@@ -85,6 +85,7 @@ function! sy#start_all() abort
   for bufnr in range(1, bufnr(''))
     call sy#start({'bufnr': bufnr})
   endfor
+  let g:signify_disable_by_default = 0
 endfunction
 
 " #stop_all {{{1
@@ -94,6 +95,7 @@ function! sy#stop_all() abort
       call sy#stop(bufnr)
     endif
   endfor
+  let g:signify_disable_by_default = 1
 endfunction
 
 " #buffer_is_active {{{1

--- a/autoload/sy/debug.vim
+++ b/autoload/sy/debug.vim
@@ -14,7 +14,7 @@ function! sy#debug#list_active_buffers() abort
 
     echo "\n". path ."\n". repeat('=', strlen(path))
 
-    for k in ['active', 'buffer', 'vcs', 'stats', 'signid']
+    for k in ['buffer', 'vcs', 'stats', 'signid']
       if k == 'stats'
         echo printf("%10s  =  %d added, %d changed, %d removed\n",
               \ k,

--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -129,7 +129,7 @@ function! s:handle_diff(options, exitval) abort
   elseif !empty(sy.updated_by) && sy.updated_by != a:options.vcs
     call sy#verbose(printf('Signs already got updated by %s.', sy.updated_by), a:options.vcs)
     return
-  elseif empty(sy.vcs) && sy.active
+  elseif empty(sy.vcs)
     let sy.detecting -= 1
   endif
 
@@ -236,7 +236,7 @@ endfunction
 
 " #debug_detection {{{1
 function! sy#repo#debug_detection()
-  if !exists('b:sy')
+  if empty(getbufvar(bufnr(''), 'sy'))
     echomsg 'signify: I cannot detect any changes!'
     return
   endif
@@ -344,8 +344,10 @@ endfunction
 
 " #diff_hunk {{{1
 function! sy#repo#diff_hunk() abort
-  if exists('b:sy') && !empty(b:sy.updated_by)
-    call sy#repo#get_diff(bufnr(''), b:sy.updated_by, function('s:diff_hunk'))
+  let bufnr = bufnr('')
+  let sy = getbufvar(bufnr, 'sy')
+  if !empty(sy) && !empty(sy.updated_by)
+    call sy#repo#get_diff(bufnr, sy.updated_by, function('s:diff_hunk'))
   endif
 endfunction
 
@@ -375,8 +377,10 @@ endfunction
 
 " #undo_hunk {{{1
 function! sy#repo#undo_hunk() abort
-  if exists('b:sy') && !empty(b:sy.updated_by)
-    call sy#repo#get_diff(bufnr(''), b:sy.updated_by, function('s:undo_hunk'))
+  let bufnr = bufnr('')
+  let sy = getbufvar(bufnr, 'sy')
+  if !empty(sy) && !empty(sy.updated_by)
+    call sy#repo#get_diff(bufnr, sy.updated_by, function('s:undo_hunk'))
   endif
 endfunction
 

--- a/autoload/sy/util.vim
+++ b/autoload/sy/util.vim
@@ -93,7 +93,8 @@ endfunction
 
 " #return_if_no_changes {{{1
 function! sy#util#return_if_no_changes() abort
-  if !exists('b:sy') || empty(b:sy.hunks)
+  let sy = getbufvar(bufnr(''), 'sy')
+  if empty(sy) || empty(sy.hunks)
     echomsg 'signify: There are no changes.'
     return 'return'
   endif

--- a/doc/signify.txt
+++ b/doc/signify.txt
@@ -230,8 +230,11 @@ Works the same as |g:signify_vcs_cmds|.
                                                   *g:signify_disable_by_default*  >
     let g:signify_disable_by_default = 0
 <
-This makes Sy not looking for changes for each new buffer. You can easily
-enable it later using |signify-:SignifyToggle|.
+Disable Sy by default. You can still enable it later via:
+
+    |signify-:SignifyToggle|
+    |signify-:SignifyEnable|
+    |signify-:SignifyEnableAll|
 
 ------------------------------------------------------------------------------
                                                *g:signify_skip_filename_pattern*
@@ -332,10 +335,22 @@ Can also be used to when a repository was initialized while Sy was already
 loaded.
 
 ------------------------------------------------------------------------------
+                                                     *signify-:SignifyEnableAll*  >
+    :SignifyEnableAll
+<
+Enable the plugin for all buffers. Sets |g:signify_disable_by_default| to 0.
+
+------------------------------------------------------------------------------
                                                        *signify-:SignifyDisable*  >
     :SignifyDisable
 <
 Disable the plugin for the current buffer only.
+
+------------------------------------------------------------------------------
+                                                    *signify-:SignifyDisableAll*  >
+    :SignifyDisableAll
+<
+Disable the plugin for all buffers. Sets |g:signify_disable_by_default| to 1.
 
 ------------------------------------------------------------------------------
                                                         *signify-:SignifyToggle*  >
@@ -462,8 +477,9 @@ User SignifySetup~
 
 User SignifyAutocmds~
 
-    This event fires every time the autocmds get set, in case you use
-    |signify-:SignifyToggle| a lot. Useful to change the default autocmds.
+    This event fires every time Sy sets autocmds. E.g. when opening a
+    version-controlled file or when using |signify-:SignifyToggle| a lot.
+    Useful to change the default |signify-autocmds|.
 
 User Signify~
 

--- a/doc/signify.txt
+++ b/doc/signify.txt
@@ -442,12 +442,12 @@ See all of them with:
 <
 You can disable sign updating for certain events:
 >
-    autocmd User SignifySetup autocmd! signify CursorHold,CursorHoldI
+    autocmd User SignifyAutocmd autocmd! signify CursorHold,CursorHoldI
 <
 If you don't need immediate feedback or responses from your VCS are slow, then
 use this to only update signs when writing the buffer:
 >
-    autocmd User SignifySetup
+    autocmd User SignifyAutocmd
           \ exe 'au! signify' | au signify BufWritePost * call sy#start()
 <
 ==============================================================================
@@ -458,7 +458,12 @@ Signify fires these user events:
 User SignifySetup~
 
     This event fires at the end of `plugin/signify.vim`, in case you want to
-    change any of the default autocmds, commands, or mappings.
+    change any of the default commands, or mappings.
+
+User SignifyAutocmds~
+
+    This event fires every time the autocmds get set, in case you use
+    |signify-:SignifyToggle| a lot. Useful to change the default autocmds.
 
 User Signify~
 
@@ -625,6 +630,9 @@ EXAMPLE                                                        *signify-example*
 
 An example configuration for Sy:
 >
+    " Faster sign updates on CursorHold/CursorHoldI
+    set updatetime=100
+
     nnoremap <leader>gd :SignifyDiff<cr>
     nnoremap <leader>gp :SignifyHunkDiff<cr>
     nnoremap <leader>gu :SignifyHunkUndo<cr>

--- a/doc/signify.txt
+++ b/doc/signify.txt
@@ -442,12 +442,12 @@ See all of them with:
 <
 You can disable sign updating for certain events:
 >
-    autocmd User SignifyAutocmd autocmd! signify CursorHold,CursorHoldI
+    autocmd User SignifyAutocmds autocmd! signify CursorHold,CursorHoldI
 <
 If you don't need immediate feedback or responses from your VCS are slow, then
 use this to only update signs when writing the buffer:
 >
-    autocmd User SignifyAutocmd
+    autocmd User SignifyAutocmds
           \ exe 'au! signify' | au signify BufWritePost * call sy#start()
 <
 ==============================================================================

--- a/plugin/signify.vim
+++ b/plugin/signify.vim
@@ -17,10 +17,13 @@ command! -nargs=0 -bar -bang SignifyDiff            call sy#repo#diffmode(<bang>
 command! -nargs=0 -bar       SignifyHunkDiff        call sy#repo#diff_hunk()
 command! -nargs=0 -bar       SignifyHunkUndo        call sy#repo#undo_hunk()
 command! -nargs=0 -bar       SignifyRefresh         call sy#util#refresh_windows()
+
 command! -nargs=0 -bar       SignifyEnable          call sy#start()
 command! -nargs=0 -bar       SignifyDisable         call sy#stop()
 command! -nargs=0 -bar       SignifyToggle          call sy#toggle()
 command! -nargs=0 -bar       SignifyToggleHighlight call sy#highlight#line_toggle()
+command! -nargs=0 -bar       SignifyEnableAll       call sy#start_all()
+command! -nargs=0 -bar       SignifyDisableAll      call sy#stop_all()
 
 " Mappings {{{1
 let s:cpoptions = &cpoptions

--- a/plugin/signify.vim
+++ b/plugin/signify.vim
@@ -58,11 +58,18 @@ xnoremap <silent> <plug>(signify-motion-outer-visual)  :<c-u>call sy#util#hunk_t
 
 let &cpoptions = s:cpoptions
 unlet s:cpoptions
-" 1}}}
 
-if !get(g:, 'signify_disable_by_default')
-  call sy#set_autocmds()
+" Autocmds {{{1
+if has('gui_running') && has('win32') && argc()
+  " Fix 'no signs at start' race.
+  autocmd GUIEnter * redraw
 endif
+
+autocmd QuickFixCmdPre  *vimgrep* let g:signify_locked = 1
+autocmd QuickFixCmdPost *vimgrep* let g:signify_locked = 0
+
+autocmd BufNewFile,BufRead * call sy#set_buflocal_autocmds(expand('<abuf>'))
+" 1}}}
 
 if exists('#User#SignifySetup')
   doautocmd <nomodeline> User SignifySetup

--- a/plugin/signify.vim
+++ b/plugin/signify.vim
@@ -68,7 +68,10 @@ endif
 autocmd QuickFixCmdPre  *vimgrep* let g:signify_locked = 1
 autocmd QuickFixCmdPost *vimgrep* let g:signify_locked = 0
 
-autocmd BufNewFile,BufRead * call sy#set_buflocal_autocmds(expand('<abuf>'))
+autocmd BufNewFile,BufRead * nested
+      \ if !get(g:, 'signify_disable_by_default') |
+      \   call sy#start({'bufnr': bufnr('')}) |
+      \ endif
 " 1}}}
 
 if exists('#User#SignifySetup')

--- a/plugin/signify.vim
+++ b/plugin/signify.vim
@@ -6,40 +6,8 @@ if exists('g:loaded_signify') || !has('signs') || &compatible
   finish
 endif
 
-" Variables {{{1
 let g:loaded_signify = 1
 let g:signify_locked = 0
-
-" Autocmds {{{1
-augroup signify
-  autocmd!
-
-  autocmd BufEnter     * call sy#start()
-  autocmd WinEnter     * call sy#start()
-  autocmd BufWritePost * call sy#start()
-
-  autocmd CursorHold   * call sy#start()
-  autocmd CursorHoldI  * call sy#start()
-
-  autocmd FocusGained  * SignifyRefresh
-
-  autocmd QuickFixCmdPre  *vimgrep* let g:signify_locked = 1
-  autocmd QuickFixCmdPost *vimgrep* let g:signify_locked = 0
-
-  autocmd CmdwinEnter * let g:signify_cmdwin_active = 1
-  autocmd CmdwinLeave * let g:signify_cmdwin_active = 0
-
-  autocmd ShellCmdPost * call sy#start()
-
-  if exists('##VimResume')
-    autocmd VimResume * call sy#start()
-  endif
-
-  if has('gui_running') && has('win32') && argc()
-    " Fix 'no signs at start' race.
-    autocmd GUIEnter * redraw
-  endif
-augroup END
 
 " Commands {{{1
 command! -nargs=0 -bar       SignifyList            call sy#debug#list_active_buffers()
@@ -49,8 +17,8 @@ command! -nargs=0 -bar -bang SignifyDiff            call sy#repo#diffmode(<bang>
 command! -nargs=0 -bar       SignifyHunkDiff        call sy#repo#diff_hunk()
 command! -nargs=0 -bar       SignifyHunkUndo        call sy#repo#undo_hunk()
 command! -nargs=0 -bar       SignifyRefresh         call sy#util#refresh_windows()
-command! -nargs=0 -bar       SignifyEnable          call sy#enable()
-command! -nargs=0 -bar       SignifyDisable         call sy#disable()
+command! -nargs=0 -bar       SignifyEnable          call sy#start()
+command! -nargs=0 -bar       SignifyDisable         call sy#stop()
 command! -nargs=0 -bar       SignifyToggle          call sy#toggle()
 command! -nargs=0 -bar       SignifyToggleHighlight call sy#highlight#line_toggle()
 
@@ -88,6 +56,10 @@ xnoremap <silent> <plug>(signify-motion-outer-visual)  :<c-u>call sy#util#hunk_t
 let &cpoptions = s:cpoptions
 unlet s:cpoptions
 " 1}}}
+
+if !get(g:, 'signify_disable_by_default')
+  call sy#set_autocmds()
+endif
 
 if exists('#User#SignifySetup')
   doautocmd <nomodeline> User SignifySetup


### PR DESCRIPTION
Before this change we only set a buffer to "inactive" on disabling, but now we also disable all autocmds.

Also works together with `let g:signify_disable_by_default = 1`.