### PR TITLE
For Neovim >0.4, don't check for external sign.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 doc/tags
+tags

--- a/autoload/sy/sign.vim
+++ b/autoload/sy/sign.vim
@@ -240,6 +240,9 @@ endfunction
 
 " s:external_sign_present {{{1
 function! s:external_sign_present(sy, line) abort
+  if has('nvim-0.4')
+    return 
+  endif
   if has_key(a:sy.external, a:line)
     if has_key(a:sy.internal, a:line)
       " Remove Sy signs from lines with other signs.

--- a/autoload/sy/sign.vim
+++ b/autoload/sy/sign.vim
@@ -240,7 +240,8 @@ endfunction
 
 " s:external_sign_present {{{1
 function! s:external_sign_present(sy, line) abort
-  if has('nvim-0.4')
+  " TODO
+  if has('nvim-0.4.0')
     return 
   endif
   if has_key(a:sy.external, a:line)


### PR DESCRIPTION
Neovim supports multiple signs in the gutter.