### PR TITLE
When b:sy is present, only disable Sy if the file disappears

### DIFF
--- a/autoload/sy.vim
+++ b/autoload/sy.vim
@@ -42,7 +42,7 @@ function! sy#start(...) abort
     return
   else
     let path = s:get_path(bufnr)
-    if s:skip(bufnr, path)
+    if !filereadable(path)
       call sy#stop()
       return
     elseif empty(sy.vcs)


### PR DESCRIPTION
In #344, we disable Sy if any condition in `s:skip()` is true.  This is too aggressive.  If `b:sy` was already set then we should prefer to leave it set, except when we can't access the file anymore.

Therefore, stop using `s:skip()` to handle this condition and simply check `filereadable()`.

Closes #347