### PR TITLE
Fix error when "hunk" does not exist in sy

### DIFF
--- a/autoload/sy/sign.vim
+++ b/autoload/sy/sign.vim
@@ -159,10 +159,10 @@ endfunction
 
 " #remove_all_signs {{{1
 function! sy#sign#remove_all_signs(bufnr) abort
-  let sy = getbufvar(a:bufnr, 'sy')
+  let sy = getbufvar(a:bufnr, 'sy', {})
 
-  for hunk in sy.hunks
-    for id in hunk.ids
+  for hunk in get(sy, 'hunks', [])
+    for id in get(hunk, 'ids', [])
       execute 'sign unplace' id 'buffer='.a:bufnr
     endfor
   endfor


### PR DESCRIPTION
### Error

```console
Error detected while processing function sy#util#refresh_windows[9]..sy#start[51]..sy#stop[3]..sy#sign#remove_all_signs:
line    3:
E716: Key not present in Dictionary: hunks
```

### Solution
Defensive programming. Ensure to have values for each required variables
in `sy#sign#remove_all_signs`.

Related to: https://github.com/mhinz/vim-signify/issues/347