### PR TITLE
Cover more cases in hunk processing to display signs

### DIFF
--- a/autoload/sy/highlight.vim
+++ b/autoload/sy/highlight.vim
@@ -7,10 +7,12 @@ if get(g:, 'signify_sign_show_text', 1)
   let s:sign_add               = get(g:, 'signify_sign_add',               '+')
   let s:sign_delete_first_line = get(g:, 'signify_sign_delete_first_line', '‾')
   let s:sign_change            = get(g:, 'signify_sign_change',            '!')
+  let s:sign_change_delete     = get(g:, 'signify_sign_change_delete', s:sign_change . s:sign_delete_first_line)
 else
   let s:sign_add               = ' '
   let s:sign_delete_first_line = ' '
   let s:sign_change            = ' '
+  let s:sign_change_delete     = ' '
 endif
 
 let s:sign_show_count = get(g:, 'signify_sign_show_count', 1)
@@ -22,17 +24,20 @@ function! sy#highlight#setup() abort
   highlight default link SignifyLineDelete          DiffDelete
   highlight default link SignifyLineDeleteFirstLine SignifyLineDelete
   highlight default link SignifyLineChange          DiffChange
+  highlight default link SignifyLineChangeDelete    SignifyLineChange
 
   highlight default link SignifySignAdd             DiffAdd
   highlight default link SignifySignDelete          DiffDelete
   highlight default link SignifySignDeleteFirstLine SignifySignDelete
   highlight default link SignifySignChange          DiffChange
+  highlight default link SignifySignChangeDelete    SignifySignChange
 endfunction
 
 " #line_enable {{{1
 function! sy#highlight#line_enable() abort
   execute 'sign define SignifyAdd text='. s:sign_add 'texthl=SignifySignAdd linehl=SignifyLineAdd'
   execute 'sign define SignifyChange text='. s:sign_change 'texthl=SignifySignChange linehl=SignifyLineChange'
+  execute 'sign define SignifyChangeDelete text='. s:sign_change_delete 'texthl=SignifySignChangeDelete linehl=SignifyLineChangeDelete'
   execute 'sign define SignifyRemoveFirstLine text='. s:sign_delete_first_line 'texthl=SignifySignDeleteFirstLine linehl=SignifyLineDeleteFirstLine'
   let g:signify_line_highlight = 1
 endfunction
@@ -41,6 +46,7 @@ endfunction
 function! sy#highlight#line_disable() abort
   execute 'sign define SignifyAdd text='. s:sign_add 'texthl=SignifySignAdd linehl='
   execute 'sign define SignifyChange text='. s:sign_change 'texthl=SignifySignChange linehl='
+  execute 'sign define SignifyChangeDelete text='. s:sign_change_delete 'texthl=SignifySignChangeDelete linehl='
   execute 'sign define SignifyRemoveFirstLine text='. s:sign_delete_first_line 'texthl=SignifySignDeleteFirstLine linehl='
   let g:signify_line_highlight = 0
 endfunction

--- a/doc/signify.txt
+++ b/doc/signify.txt
@@ -131,6 +131,7 @@ default values, as long as no "Default:" section is given.
     |g:signify_sign_delete|
     |g:signify_sign_delete_first_line|
     |g:signify_sign_change|
+    |g:signify_sign_change_delete|
     |g:signify_sign_show_count|
     |g:signify_sign_show_text|
     |g:signify_difftool|
@@ -267,11 +268,13 @@ Enable line highlighting in addition to using signs by default.
                                               *g:signify_sign_delete*
                                               *g:signify_sign_delete_first_line*
                                               *g:signify_sign_change*
+                                              *g:signify_sign_change_delete*
 >
     let g:signify_sign_add               = '+'
     let g:signify_sign_delete            = '_'
     let g:signify_sign_delete_first_line = '‾'
     let g:signify_sign_change            = '!'
+    let g:signify_sign_change_delete     = g:signify_sign_change . g:signify_sign_delete_first_line
 <
 The sign to use if a line was added, deleted or changed or a combination of
 these.
@@ -548,11 +551,13 @@ highlighting groups: |hl-DiffAdd|, |hl-DiffChange|, |hl-DiffDelete|:
 >
     highlight link SignifyLineAdd             DiffAdd
     highlight link SignifyLineChange          DiffChange
+    highlight link SignifyLineChangeDelete    SignifyLineChange
     highlight link SignifyLineDelete          DiffDelete
     highlight link SignifyLineDeleteFirstLine SignifyLineDelete
 
     highlight link SignifySignAdd             DiffAdd
     highlight link SignifySignChange          DiffChange
+    highlight link SignifySignChangeDelete    SignifySignChange
     highlight link SignifySignDelete          DiffDelete
     highlight link SignifySignDeleteFirstLine SignifySignDelete
 <


### PR DESCRIPTION
Add 3 new cases:
1. Number of lines before and after is the same. Mark all lines as modified.
2. Number of lines before is smaller than after, it means some new lines are added. Mark first lines as modified and the rest as added.
<img width="349" alt="Screenshot 2021-01-21 at 18 26 47" src="https://user-images.githubusercontent.com/3767331/105395053-3ac5a780-5c16-11eb-8cf3-b83039aa2455.png">
3. Number of lines before is greater than after, some lines are removed. Mark all lines as modified and add sign for removed lines.
<img width="284" alt="Screenshot 2021-01-21 at 18 28 27" src="https://user-images.githubusercontent.com/3767331/105395279-76607180-5c16-11eb-8630-75c7c035fdb8.png">

Also to cover corner cases this introduces new hightlights: `SignifyLineChangeDelete` and `SignifySignChangeDelete`. This is for third case when there are no lines before current chunk or when previous line is already taken by different sign.
<img width="192" alt="Screenshot 2021-01-21 at 18 29 47" src="https://user-images.githubusercontent.com/3767331/105395448-a4de4c80-5c16-11eb-8db8-0181d282bb44.png">
By default sign for such case is `'!‾'` but it can be changed by `g:signify_sign_change_delete` which I added to the docs.

This is inspired by `vim-gitgutter` mainly.

Fixes #350 