### PR TITLE
Fix undo hunk

### DIFF
--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -413,7 +413,7 @@ function! s:undo_hunk(sy, vcs, diff) abort
     return
   endif
 
-  let [_old_line, _old_count, new_line, _new_count] = sy#sign#parse_hunk(header)
+  let [_old_line, _old_count, new_line, new_count] = sy#sign#parse_hunk(header)
 
   for line in hunk
     let op = line[0]
@@ -425,7 +425,7 @@ function! s:undo_hunk(sy, vcs, diff) abort
       endif
       let new_line += 1
     elseif op == '-'
-      call append(new_line-1, text)
+      call append(new_count == 0 ? new_line : new_line - 1, text)
       let new_line += 1
     elseif op == '+'
       if text != getline(new_line)


### PR DESCRIPTION
Fixes #345 

When `new_count` is `0` it's a special case meaning that lines should be inserted after `new_line`, not instead of it.

When you remove `line 2` from file:
```
line 1
line 2
line 3
line 4
```
the diff looks line this:
```diff
index 9c2a709..cbf7f40 100644
--- a/test.txt
+++ b/test.txt
@@ -2 +1,0 @@ line 1
-line 2
```

It means `line 2` in `undo` should be inserted below line 1 (`new_line`) and before it was inserted after line 0 (`new_line - 1`).