### PR TITLE
Show 'Hunk X of Y' on jumps

### DIFF
--- a/autoload/sy/jump.vim
+++ b/autoload/sy/jump.vim
@@ -2,17 +2,36 @@
 
 scriptencoding utf-8
 
+" s:jump_to_hunk {{{1
+function! s:jump_to_hunk(hunk_idx)
+  let hunk = b:sy.hunks[a:hunk_idx]
+  let hunks_len = len(b:sy.hunks)
+  execute 'sign jump '. hunk.ids[0] .' buffer='. b:sy.buffer
+  echo printf('Hunk %d of %d', a:hunk_idx + 1, hunks_len)
+endfunction
+
 " #next_hunk {{{1
 function! sy#jump#next_hunk(count)
   execute sy#util#return_if_no_changes()
 
   let lnum = line('.')
-  let hunks = filter(copy(b:sy.hunks), 'v:val.start > lnum')
-  let hunk = get(hunks, a:count - 1, get(hunks, -1, {}))
-
-  if !empty(hunk)
-    execute 'sign jump '. hunk.ids[0] .' buffer='. b:sy.buffer
+  let hunks_len = len(b:sy.hunks)
+  if a:count > hunks_len
+    call s:jump_to_hunk(hunks_len - 1)
+    return
   endif
+  let idx = 0
+  while idx < hunks_len
+    if b:sy.hunks[idx].start > lnum
+      let target_idx = idx + a:count - 1
+      if target_idx >= hunks_len
+        let target_idx = hunks_len - 1
+      endif
+      call s:jump_to_hunk(target_idx)
+      break
+    endif
+    let idx += 1
+  endwhile
 endfunction
 
 " #prev_hunk {{{1
@@ -20,10 +39,21 @@ function! sy#jump#prev_hunk(count)
   execute sy#util#return_if_no_changes()
 
   let lnum = line('.')
-  let hunks = filter(copy(b:sy.hunks), 'v:val.start < lnum')
-  let hunk = get(hunks, 0 - a:count, get(hunks, 0, {}))
-
-  if !empty(hunk)
-    execute 'sign jump '. hunk.ids[0] .' buffer='. b:sy.buffer
+  let hunks_len = len(b:sy.hunks)
+  if a:count > hunks_len
+    call s:jump_to_hunk(0)
+    return
   endif
+  let idx = hunks_len - 1
+  while idx >= 0
+    if b:sy.hunks[idx].start < lnum
+      let target_idx = idx - a:count + 1
+      if target_idx < 0
+        let target_idx = 0
+      endif
+      call s:jump_to_hunk(target_idx)
+      break
+    endif
+    let idx -= 1
+  endwhile
 endfunction


### PR DESCRIPTION
Inspired by `vim-gitgutter`. Show which hunk we're jumping to:
<img width="214" alt="Screenshot 2021-01-22 at 23 56 14" src="https://user-images.githubusercontent.com/3767331/105560977-6b3c3d00-5d0d-11eb-9f48-c637c231cdf8.png">

Also optimise code a bit: 
- Optimise go to the first and last hunks. 
- Don't iterate over the whole list of hunks, break on the first item which matches the search criteria. 
- Don't create a new copy of hunks. 

Can be optimised even further with binary search but number of hunks is usually quite small, so linear search should be just fine.

If you prefer, I can make this optional but I think it's good to have this by default.