### PR TITLE
Override g:signify_sign_change_delete if it is too wide

### DIFF
--- a/autoload/sy/highlight.vim
+++ b/autoload/sy/highlight.vim
@@ -8,6 +8,10 @@ if get(g:, 'signify_sign_show_text', 1)
   let s:sign_delete_first_line = get(g:, 'signify_sign_delete_first_line', '‾')
   let s:sign_change            = get(g:, 'signify_sign_change',            '!')
   let s:sign_change_delete     = get(g:, 'signify_sign_change_delete', s:sign_change . s:sign_delete_first_line)
+  if strdisplaywidth(s:sign_change_delete) > 2
+    call sy#verbose(printf('Changing g:signify_sign_change_delete from %s to !- to avoid E239', s:sign_change_delete))
+    let s:sign_change_delete = '!-'
+  endif
 else
   let s:sign_add               = ' '
   let s:sign_delete_first_line = ' '


### PR DESCRIPTION
Since the default config is a combination of `g:signify_sign_change` and `g:signify_sign_delete_first_line`, it may be too wide for the sign columns (either due to 'ambiwidth' being set to "double" or one of the signs being customized to two characters).

Emit a diagnostic for why this is being overridden so there's at least a hint of what's going on.

Closes #366