### PR TITLE
Add support for highlighting the number column

### DIFF
--- a/autoload/sy/highlight.vim
+++ b/autoload/sy/highlight.vim
@@ -31,19 +31,19 @@ endfunction
 
 " #line_enable {{{1
 function! sy#highlight#line_enable() abort
-  execute 'sign define SignifyAdd text='. s:sign_add 'texthl=SignifySignAdd linehl=SignifyLineAdd'
-  execute 'sign define SignifyChange text='. s:sign_change 'texthl=SignifySignChange linehl=SignifyLineChange'
-  execute 'sign define SignifyChangeDelete text='. s:sign_change_delete 'texthl=SignifySignChangeDelete linehl=SignifyLineChangeDelete'
-  execute 'sign define SignifyRemoveFirstLine text='. s:sign_delete_first_line 'texthl=SignifySignDeleteFirstLine linehl=SignifyLineDeleteFirstLine'
+  execute 'sign define SignifyAdd text='. s:sign_add ' texthl=SignifySignAdd linehl=SignifyLineAdd '. sy#util#numhl('SignifySignAdd')
+  execute 'sign define SignifyChange text='. s:sign_change ' texthl=SignifySignChange linehl=SignifyLineChange '. sy#util#numhl('SignifySignChange')
+  execute 'sign define SignifyChangeDelete text='. s:sign_change_delete ' texthl=SignifySignChangeDelete linehl=SignifyLineChangeDelete '. sy#util#numhl('SignifySignChangeDelete')
+  execute 'sign define SignifyRemoveFirstLine text='. s:sign_delete_first_line ' texthl=SignifySignDeleteFirstLine linehl=SignifyLineDeleteFirstLine '. sy#util#numhl('SignifySignDeleteFirstLine')
   let g:signify_line_highlight = 1
 endfunction
 
 " #line_disable {{{1
 function! sy#highlight#line_disable() abort
-  execute 'sign define SignifyAdd text='. s:sign_add 'texthl=SignifySignAdd linehl='
-  execute 'sign define SignifyChange text='. s:sign_change 'texthl=SignifySignChange linehl='
-  execute 'sign define SignifyChangeDelete text='. s:sign_change_delete 'texthl=SignifySignChangeDelete linehl='
-  execute 'sign define SignifyRemoveFirstLine text='. s:sign_delete_first_line 'texthl=SignifySignDeleteFirstLine linehl='
+  execute 'sign define SignifyAdd text='. s:sign_add ' texthl=SignifySignAdd linehl= '. sy#util#numhl('SignifySignAdd')
+  execute 'sign define SignifyChange text='. s:sign_change ' texthl=SignifySignChange linehl= '. sy#util#numhl('SignifySignChange')
+  execute 'sign define SignifyChangeDelete text='. s:sign_change_delete ' texthl=SignifySignChangeDelete linehl= '. sy#util#numhl('SignifySignChangeDelete')
+  execute 'sign define SignifyRemoveFirstLine text='. s:sign_delete_first_line ' texthl=SignifySignDeleteFirstLine linehl= '. sy#util#numhl('SignifySignDeleteFirstLine')
   let g:signify_line_highlight = 0
 endfunction
 

--- a/autoload/sy/sign.vim
+++ b/autoload/sy/sign.vim
@@ -280,10 +280,11 @@ function! s:add_sign(sy, line, type, ...) abort
   endif
 
   if a:type =~# 'SignifyDelete'
-    execute printf('sign define %s text=%s texthl=SignifySignDelete linehl=%s',
+    execute printf('sign define %s text=%s texthl=SignifySignDelete linehl=%s %s',
           \ a:type,
           \ a:1,
-          \ s:delete_highlight[g:signify_line_highlight])
+          \ s:delete_highlight[g:signify_line_highlight],
+          \ sy#util#numhl('SignifySignDelete'))
   endif
   execute printf('sign place %d line=%d name=%s %s buffer=%s',
         \ id,

--- a/autoload/sy/util.vim
+++ b/autoload/sy/util.vim
@@ -195,6 +195,27 @@ function! sy#util#popup_create(hunkdiff) abort
   return 1
 endfunction
 
+" #numhl {{{1
+try
+  sign define SyTest numhl=Number
+  let s:use_numhl = 1
+  sign undefine SyTest
+catch
+  let s:use_numhl = 0
+endtry
+
+function! sy#util#numhl(hlgroup) abort
+  if !s:use_numhl
+    return ''
+  endif
+
+  if get(g:, 'signify_number_highlight')
+    return printf('numhl=%s', a:hlgroup)
+  else
+    return 'numhl='
+  endif
+endfunction
+
 " s:offset {{{1
 function! s:offset() abort
   let offset = &foldcolumn

--- a/doc/signify.txt
+++ b/doc/signify.txt
@@ -263,6 +263,14 @@ Default: <none>
 Enable line highlighting in addition to using signs by default.
 
 ------------------------------------------------------------------------------
+                                                    *g:signify_number_highlight*  >
+    let g:signify_number_highlight = 0
+<
+Enable number column highlighting in addition to using signs by default.
+
+This requires Vim 8.2.3874+ or Neovim 0.3.2+.
+
+------------------------------------------------------------------------------
                                               *g:signify_sign_add*
                                               *g:signify_sign_delete*
                                               *g:signify_sign_delete_first_line*


### PR DESCRIPTION
`g:signify_number_higlight` can be used to enable highlighting the number column for the placed signs.

This requires Vim 8.2.3874/Neovim 0.3.2 or newer.

Closes #387