### PR TITLE
Defer VCS detection when too many jobs are running

### DIFF
--- a/autoload/sy.vim
+++ b/autoload/sy.vim
@@ -10,6 +10,11 @@ function! sy#start(...) abort
     return
   endif
 
+  if g:signify_detecting > 50
+    call sy#verbose('Too many detection jobs running, deferring detection')
+    return
+  endif
+
   let bufnr = a:0 && has_key(a:1, 'bufnr') ? a:1.bufnr : bufnr('')
   let sy = getbufvar(bufnr, 'sy')
 

--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -7,6 +7,7 @@ function! sy#repo#detect(bufnr) abort
   let sy = getbufvar(a:bufnr, 'sy')
   for vcs in s:vcs_list
     let sy.detecting += 1
+    let g:signify_detecting += 1
     call sy#repo#get_diff(a:bufnr, vcs, function('sy#sign#set_signs'))
   endfor
 endfunction
@@ -130,6 +131,7 @@ function! s:handle_diff(options, exitval) abort
     call sy#verbose(printf('Signs already got updated by %s.', sy.updated_by), a:options.vcs)
     return
   elseif empty(sy.vcs)
+    let g:signify_detecting -= 1
     let sy.detecting -= 1
   endif
 

--- a/plugin/signify.vim
+++ b/plugin/signify.vim
@@ -8,6 +8,7 @@ endif
 
 let g:loaded_signify = 1
 let g:signify_locked = 0
+let g:signify_detecting = 0
 
 " Commands {{{1
 command! -nargs=0 -bar       SignifyList            call sy#debug#list_active_buffers()


### PR DESCRIPTION
In cases like using `:cfdo`, many buffers may be quickly visited, thus starting lots of VCS detection jobs.  This can lead to the (n)vim process having too many open files and all the detection jobs noisily failing.

Limit VCS detection to 50 concurrent jobs to mitigate this problem. Since `b:sy` is not being set when detection is deferred, the next visit to the buffer will still run VCS detection.

Closes #333