### PR TITLE
parse signlist locale agnostic

### DIFF
--- a/autoload/sy/fold.vim
+++ b/autoload/sy/fold.vim
@@ -88,24 +88,7 @@ endfunction
 
 " s:get_lines {{{1
 function! s:get_lines() abort
-  let lines = []
-
-  let has_sign_func = has('patch-8.1.614')
-  if has_sign_func
-    let signlist = sign_getplaced(b:sy.buffer)[0].signs
-  else
-    let signlist = split(sy#util#execute('sign place buffer='. b:sy.buffer), '\n')[2:]
-  endif
-
-  for signline in signlist
-    if has_sign_func
-      call insert(lines, signline.lnum, 0)
-    else
-      call insert(lines, matchlist(line, '\v^\s+line\=(\d+)')[1], 0)
-    endif
-  endfor
-
-  return reverse(lines)
+  return map(sy#util#get_signs(b:sy.buffer), {_, val -> val.lnum})
 endfunction
 
 " s:get_levels {{{1

--- a/autoload/sy/fold.vim
+++ b/autoload/sy/fold.vim
@@ -88,11 +88,21 @@ endfunction
 
 " s:get_lines {{{1
 function! s:get_lines() abort
-  let signlist = sy#util#execute('sign place buffer='. b:sy.buffer)
-
   let lines = []
-  for line in split(signlist, '\n')[2:]
-    call insert(lines, matchlist(line, '\v^\s+line\=(\d+)')[1], 0)
+
+  let has_sign_func = has('patch-8.1.614')
+  if has_sign_func
+    let signlist = sign_getplaced(b:sy.buffer)[0].signs
+  else
+    let signlist = split(sy#util#execute('sign place buffer='. b:sy.buffer), '\n')[2:]
+  endif
+
+  for signline in signlist
+    if has_sign_func
+      call insert(lines, signline.lnum, 0)
+    else
+      call insert(lines, matchlist(line, '\v^\s+line\=(\d+)')[1], 0)
+    endif
   endfor
 
   return reverse(lines)

--- a/autoload/sy/sign.vim
+++ b/autoload/sy/sign.vim
@@ -28,13 +28,24 @@ function! sy#sign#get_current_signs(sy) abort
   let a:sy.internal = {}
   let a:sy.external = {}
 
-  let signlist = sy#util#execute('sign place buffer='. a:sy.buffer)
+  let has_sign_func = has('patch-8.1.614')
+  if has_sign_func
+    let signlist = sign_getplaced(a:sy.buffer)[0].signs
+  else
+    let signlist = split(sy#util#execute('sign place buffer='. a:sy.buffer), '\n')[2:]
+  endif
 
-  for signline in split(signlist, '\n')[2:]
-    let tokens = matchlist(signline, '\v^\s+\S+\=(\d+)\s+\S+\=(\d+)\s+\S+\=(.*)$')
-    let line   = str2nr(tokens[1])
-    let id     = str2nr(tokens[2])
-    let type   = tokens[3]
+  for signline in signlist
+    if has_sign_func
+      let line   = signline.lnum
+      let id     = signline.id
+      let type   = signline.name
+    else
+      let tokens = matchlist(signline, '\v^\s+\S+\=(\d+)\s+\S+\=(\d+)\s+\S+\=(.*)$')
+      let line   = str2nr(tokens[1])
+      let id     = str2nr(tokens[2])
+      let type   = tokens[3]
+    endif
 
     if type =~# '^Signify'
       " Handle ambiguous signs. Assume you have signs on line 3 and 4.

--- a/autoload/sy/sign.vim
+++ b/autoload/sy/sign.vim
@@ -28,35 +28,19 @@ function! sy#sign#get_current_signs(sy) abort
   let a:sy.internal = {}
   let a:sy.external = {}
 
-  let has_sign_func = has('patch-8.1.614')
-  if has_sign_func
-    let signlist = sign_getplaced(a:sy.buffer)[0].signs
-  else
-    let signlist = split(sy#util#execute('sign place buffer='. a:sy.buffer), '\n')[2:]
-  endif
+  let signlist = sy#util#get_signs(a:sy.buffer)
 
-  for signline in signlist
-    if has_sign_func
-      let line   = signline.lnum
-      let id     = signline.id
-      let type   = signline.name
-    else
-      let tokens = matchlist(signline, '\v^\s+\S+\=(\d+)\s+\S+\=(\d+)\s+\S+\=(.*)$')
-      let line   = str2nr(tokens[1])
-      let id     = str2nr(tokens[2])
-      let type   = tokens[3]
-    endif
-
-    if type =~# '^Signify'
+  for sign in signlist
+    if sign.name =~# '^Signify'
       " Handle ambiguous signs. Assume you have signs on line 3 and 4.
       " Removing line 3 would lead to the second sign to be shifted up
       " to line 3. Now there are still 2 signs, both one line 3.
-      if has_key(a:sy.internal, line)
-        execute 'sign unplace' a:sy.internal[line].id 'buffer='.a:sy.buffer
+      if has_key(a:sy.internal, sign.lnum)
+        execute 'sign unplace' a:sy.internal[sign.lnum].id 'buffer='.a:sy.buffer
       endif
-      let a:sy.internal[line] = { 'type': type, 'id': id }
+      let a:sy.internal[sign.lnum] = { 'type': sign.name, 'id': sign.id }
     else
-      let a:sy.external[line] = id
+      let a:sy.external[sign.lnum] = sign.id
     endif
   endfor
 endfunction

--- a/autoload/sy/util.vim
+++ b/autoload/sy/util.vim
@@ -229,3 +229,33 @@ function! s:offset() abort
   endif
   return offset
 endfunction
+
+" #get_signs {{{1
+if exists('*sign_getplaced')
+  function! sy#util#get_signs(bufnr)
+    return sign_getplaced(a:bufnr)[0].signs
+  endfunction
+else
+  function! sy#util#get_signs(bufnr)
+    let buf = bufnr(a:bufnr)
+    let signs = []
+
+    let signlist = execute('sign place buffer='. buf)
+    for signline in split(signlist, '\n')[2:]
+      let tokens = matchlist(signline, '\v^\s+\S+\=(\d+)\s+\S+\=(\d+)\s+\S+\=(.*)\s+\S+\=(\d+)$')
+      let line   = str2nr(tokens[1])
+      let id     = str2nr(tokens[2])
+      let name   = tokens[3]
+      let priority = str2nr(tokens[4])
+      call add(signs, {
+            \ 'lnum': line,
+            \ 'id': id,
+            \ 'name': name,
+            \ 'priority': priority,
+            \ 'group': ''
+            \ })
+    endfor
+
+    return signs
+  endfunction
+endif


### PR DESCRIPTION
In spanish the signlist output is:

```
línea=146 id=256 nombre=SignifyAdd prioridad=10
...
```

changing the parse for this lines, plugin works again