### PR TITLE
Clean undo history for :SignifyDiff

### DIFF
--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -310,6 +310,10 @@ function! sy#repo#diffmode(do_tab) abort
   let base = s:get_base(bufnr(''), vcs)
 
   leftabove vnew
+
+  let undolevels = &l:undolevels
+  setlocal undolevels=-1
+
   if (fenc != &enc) && has('iconv')
     silent put =iconv(base, fenc, &enc)
   else
@@ -319,6 +323,7 @@ function! sy#repo#diffmode(do_tab) abort
   silent 1delete
   set buftype=nofile bufhidden=wipe nomodified
   let &filetype = ft
+  let &l:undolevels = undolevels
   diffthis
   wincmd p
   normal! ]czt


### PR DESCRIPTION
# current behavior

After `:SignifyDiff`, press "u" on the `[Scratch]` buffer, the buffer content is cleared.

That is, undo works for the code below from repo.vim.

```vim
   if (fenc != &enc) && has('iconv')
      silent put =iconv(base, fenc, &enc)
    else
      silent put =base
    endif

    silent 1delete
```

# this PR

`setlocal undolevels=1` before `put =base` and restore the value after `silent 1delete`.

- undo does not work for the initial content of `:SignifyDiff`.
- undo works for the changes after `:SignifyDiff`.