### PR TITLE
Make fold levels be buffer local.

### DIFF
--- a/autoload/sy/fold.vim
+++ b/autoload/sy/fold.vim
@@ -2,7 +2,7 @@
 
 " SignifyFoldExpr {{{1
 function! SignifyFoldExpr(lnum)
-  return s:levels[a:lnum]
+  return b:levels[a:lnum]
 endfunction
 
 " SignifyFoldText {{{1
@@ -48,8 +48,8 @@ function! sy#fold#enable(do_tab) abort
     tabedit %
   endif
 
-  let [s:context0, s:context1] = get(g:, 'signify_fold_context', [3, 8])
-  let s:levels = s:get_levels(s:get_lines())
+  let [context0, context1] = get(g:, 'signify_fold_context', [3, 8])
+  let b:levels = s:get_levels(s:get_lines(), context0, context1)
 
   setlocal foldexpr=SignifyFoldExpr(v:lnum)
   setlocal foldtext=SignifyFoldText()
@@ -92,7 +92,7 @@ function! s:get_lines() abort
 endfunction
 
 " s:get_levels {{{1
-function! s:get_levels(lines) abort
+function! s:get_levels(lines, context0, context1) abort
   let levels = {}
 
   for line in range(1, line('$'))
@@ -100,14 +100,14 @@ function! s:get_levels(lines) abort
   endfor
 
   for line in a:lines
-    for l in range(line - s:context1, line + s:context1)
+    for l in range(line - context1, line + context1)
       if (l < 1) || (l > line('$'))
         continue
       endif
       if levels[l] == 2
         let levels[l] = 1
       endif
-      for ll in range(line - s:context0, line + s:context0)
+      for ll in range(line - context0, line + context0)
         let levels[ll] = 0
       endfor
     endfor


### PR DESCRIPTION
Without this I had behavior where doing `SignifyFold!` on a second buffer would change the fold regions of the first buffer. With the fix things were independent as they should be.