### PR TITLE
Fixing a Perforce issue where the first line of the modified buffer is marked as deleted

### DIFF
--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -643,7 +643,7 @@ let s:default_vcs_cmds_diffmode = {
       \ 'cvs':      'cvs up -p -- %f 2>%n',
       \ 'rcs':      'co -q -p %f',
       \ 'accurev':  'accurev cat %f',
-      \ 'perforce': 'p4 print %f',
+      \ 'perforce': 'p4 print -q %f',
       \ 'tfs':      'tf view -version:W -noprompt %f',
       \ }
 

--- a/doc/signify.txt
+++ b/doc/signify.txt
@@ -217,7 +217,7 @@ Default:
       \ 'cvs':      'cvs up -p -- %f 2>%n',
       \ 'rcs':      'co -q -p %f',
       \ 'accurev':  'accurev cat %f',
-      \ 'perforce': 'p4 print %f',
+      \ 'perforce': 'p4 print -q %f',
       \ 'tfs':      'tf view -version:W -noprompt %f',
       \ }
 <


### PR DESCRIPTION
Another simple fix related to Perforce.

Since ```p4 print``` outputs the file path as a header on the first line, Signify always marks the first line of the modified buffer as deleted. As stated in their [documentation](https://help.perforce.com/helix-core/server-apps/cmdref/current/Content/CmdRef/p4_print.html), we can fix this by using the ```-q``` option.