### PR TITLE
Fix job accumulation leak causing unbounded memory growth

### DIFF
--- a/autoload/sy/repo.vim
+++ b/autoload/sy/repo.vim
@@ -85,6 +85,10 @@ function! sy#repo#get_diff(bufnr, vcs, func) abort
 
   let options.func = a:func
 
+  let s:job_gen = get(s:, 'job_gen', 0) + 1
+  let options.job_gen = s:job_gen
+  call setbufvar(a:bufnr, 'sy_job_gen_'.a:vcs, s:job_gen)
+
   if has('nvim')
     if job_id
       silent! call jobstop(job_id)
@@ -151,7 +155,12 @@ function! s:handle_diff(options, exitval) abort
     call sy#verbose('No valid diff found. Disabling this VCS.', a:options.vcs)
   endif
 
-  call setbufvar(a:options.bufnr, 'sy_job_id_'.a:options.vcs, 0)
+  " Only clear the job marker if this is still the current job.
+  " A stale job's callback must not clobber a newer job's marker,
+  " otherwise the newer job becomes orphaned and never gets stopped.
+  if get(a:options, 'job_gen', -1) == getbufvar(a:options.bufnr, 'sy_job_gen_'.a:options.vcs, -2)
+    call setbufvar(a:options.bufnr, 'sy_job_id_'.a:options.vcs, 0)
+  endif
 endfunction
 
 " s:check_diff_diff {{{1


### PR DESCRIPTION
A race condition in handle_diff caused orphaned jobs to pile up over
long sessions. When a job was stopped and replaced, the old job's
close_cb would clear the buffer variable tracking the new job. This
left the new job untracked, so subsequent updates never stopped it
before starting another cascading into thousands of concurrent
orphaned jobs, each holding its options dict and stdout buffer.

Fix by tagging each job with a generation counter so stale callbacks
don't clobber the current job's marker.